### PR TITLE
Add addPolicy command

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -21,6 +21,8 @@ public class Messages {
     public static final String MESSAGE_SCHEDULE_DONE = "This schedule has already been completed.";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
+    public static final String MESSAGE_DUPLICATE_POLICY =
+            "You cannot add a policy with the same Policy ID as an existing policy";
 
     /**
      * Returns an error message indicating the duplicate prefixes.

--- a/src/main/java/seedu/address/logic/commands/AddPolicyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddPolicyCommand.java
@@ -1,0 +1,103 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_POLICYID;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_POLICYNAME;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+
+import java.util.List;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.PolicyList;
+import seedu.address.model.policy.Policy;
+
+
+/**
+ * Adds a policy to person.
+ */
+public class AddPolicyCommand extends Command {
+    public static final String COMMAND_WORD = "addpolicy";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": add a new policy to the client's policy list. "
+            + "Parameters: "
+            + "INDEX "
+            + PREFIX_POLICYNAME + "POLICYNAME "
+            + PREFIX_POLICYID + "POLICYID\n"
+            + "Example: " + COMMAND_WORD + " "
+            + "1 "
+            + PREFIX_POLICYNAME + "Travel Bali "
+            + PREFIX_POLICYID + "123";
+
+    public static final String MESSAGE_SUCCESS = "You have added a policy to %1$s.";
+    private final Index index;
+    private final Policy policy;
+
+    /**
+     * Creates a AddPolicyCommand to add a policy to specified {@code Person}
+     */
+    public AddPolicyCommand(Index index, Policy policy) {
+        requireNonNull(index);
+        requireNonNull(policy);
+
+        this.index = index;
+        this.policy = policy;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        List<Person> lastShownList = model.getFilteredPersonList();
+
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        Person personToAddPolicy = lastShownList.get(index.getZeroBased());
+
+        // Checks for conflicting Policy ID here
+        if (personToAddPolicy.hasPolicyID(policy)) {
+            throw new CommandException(Messages.MESSAGE_DUPLICATE_POLICY);
+        }
+        PolicyList updatedPolicyList = personToAddPolicy.getPolicyList().getPolicyListClone();
+        updatedPolicyList.addPolicy(policy);
+
+        Person policyAddedPerson = new Person(personToAddPolicy.getName(), personToAddPolicy.getPhone(),
+                personToAddPolicy.getEmail(), personToAddPolicy.getAddress(), personToAddPolicy.getBirthday(),
+                personToAddPolicy.getLastMet(), personToAddPolicy.getSchedule(), personToAddPolicy.getTags(),
+                updatedPolicyList);
+
+        model.setPerson(personToAddPolicy, policyAddedPerson);
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+
+        return new CommandResult(String.format(MESSAGE_SUCCESS, personToAddPolicy.getName()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof AddPolicyCommand)) {
+            return false;
+        }
+
+        AddPolicyCommand otherAddPolicyCommand = (AddPolicyCommand) other;
+        return index.equals(otherAddPolicyCommand.index) && policy.equals(otherAddPolicyCommand.policy);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("index", index)
+                .add("addPolicy", policy)
+                .toString();
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -29,6 +29,7 @@ import seedu.address.model.person.LastMet;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.PolicyList;
 import seedu.address.model.person.Schedule;
 import seedu.address.model.tag.Tag;
 
@@ -108,9 +109,10 @@ public class EditCommand extends Command {
         LastMet currentLastMet = personToEdit.getLastMet();
         Schedule currentSchedule = personToEdit.getSchedule();
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
+        PolicyList currentPolicyList = personToEdit.getPolicyList();
 
         return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedBirthday,
-                currentLastMet, currentSchedule, updatedTags);
+                currentLastMet, currentSchedule, updatedTags, currentPolicyList);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/LastMetCommand.java
+++ b/src/main/java/seedu/address/logic/commands/LastMetCommand.java
@@ -66,7 +66,7 @@ public class LastMetCommand extends Command {
         Person metPerson = new Person(
                 personToMeet.getName(), personToMeet.getPhone(), personToMeet.getEmail(),
                 personToMeet.getAddress(), personToMeet.getBirthday(),
-                this.lastMet, personToMeet.getSchedule(), personToMeet.getTags());
+                this.lastMet, personToMeet.getSchedule(), personToMeet.getTags(), personToMeet.getPolicyList());
 
         model.setPerson(personToMeet, metPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);

--- a/src/main/java/seedu/address/logic/commands/MarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkCommand.java
@@ -57,7 +57,8 @@ public class MarkCommand extends Command {
         Person metPerson = new Person(
                 personToMeet.getName(), personToMeet.getPhone(), personToMeet.getEmail(),
                 personToMeet.getAddress(), personToMeet.getBirthday(),
-                personToMeet.getLastMet(), personToMeet.getSchedule(), personToMeet.getTags());
+                personToMeet.getLastMet(), personToMeet.getSchedule(), personToMeet.getTags(),
+                personToMeet.getPolicyList());
 
         metPerson.getSchedule().markIsDone();
         model.setPerson(personToMeet, metPerson);

--- a/src/main/java/seedu/address/logic/commands/ScheduleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ScheduleCommand.java
@@ -66,7 +66,7 @@ public class ScheduleCommand extends Command {
         Person metPerson = new Person(
                 personToMeet.getName(), personToMeet.getPhone(), personToMeet.getEmail(),
                 personToMeet.getAddress(), personToMeet.getBirthday(),
-                personToMeet.getLastMet(), this.schedule, personToMeet.getTags());
+                personToMeet.getLastMet(), this.schedule, personToMeet.getTags(), personToMeet.getPolicyList());
 
         model.setPerson(personToMeet, metPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);

--- a/src/main/java/seedu/address/logic/parser/AddPolicyCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddPolicyCommandParser.java
@@ -1,0 +1,58 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_POLICYID;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_POLICYNAME;
+
+import java.util.stream.Stream;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.logic.commands.AddPolicyCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.policy.Policy;
+
+
+/**
+ * Parses input arguments and creates a new ScheduleCommand object
+ */
+public class AddPolicyCommandParser {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the ScheduleCommand
+     * and returns an ScheduleCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public AddPolicyCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_POLICYNAME, PREFIX_POLICYID);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_POLICYNAME, PREFIX_POLICYID)
+                || argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddPolicyCommand.MESSAGE_USAGE));
+        }
+
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_POLICYNAME, PREFIX_POLICYID);
+
+        Index index;
+        try {
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (IllegalValueException ive) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    AddPolicyCommand.MESSAGE_USAGE), ive);
+        }
+
+        Policy policy = ParserUtil.parsePolicyInfo(argMultimap.getValue(PREFIX_POLICYNAME).get(),
+                argMultimap.getValue(PREFIX_POLICYID).get());
+        return new AddPolicyCommand(index, policy);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -9,6 +9,7 @@ import java.util.regex.Pattern;
 
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.AddPolicyCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
@@ -88,6 +89,9 @@ public class AddressBookParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case AddPolicyCommand.COMMAND_WORD:
+            return new AddPolicyCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -15,5 +15,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_SCHEDULE = new Prefix("d/");
     public static final Prefix PREFIX_BIRTHDAY = new Prefix("d/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
+    public static final Prefix PREFIX_POLICYNAME = new Prefix("n/");
+    public static final Prefix PREFIX_POLICYID = new Prefix("i/");
 
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -14,10 +14,11 @@ import seedu.address.model.person.Birthday;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
+import seedu.address.model.policy.Policy;
 import seedu.address.model.tag.Tag;
 
 /**
- * Contains utility methods used for parsing strings in the various *Parser classes.
+ * The type Parser util.
  */
 public class ParserUtil {
 
@@ -26,6 +27,9 @@ public class ParserUtil {
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
      * trimmed.
+     *
+     * @param oneBasedIndex the one based index
+     * @return the index
      * @throws ParseException if the specified index is invalid (not non-zero unsigned integer).
      */
     public static Index parseIndex(String oneBasedIndex) throws ParseException {
@@ -40,6 +44,8 @@ public class ParserUtil {
      * Parses a {@code String name} into a {@code Name}.
      * Leading and trailing whitespaces will be trimmed.
      *
+     * @param name the name
+     * @return the name
      * @throws ParseException if the given {@code name} is invalid.
      */
     public static Name parseName(String name) throws ParseException {
@@ -55,6 +61,8 @@ public class ParserUtil {
      * Parses a {@code String phone} into a {@code Phone}.
      * Leading and trailing whitespaces will be trimmed.
      *
+     * @param phone the phone
+     * @return the phone
      * @throws ParseException if the given {@code phone} is invalid.
      */
     public static Phone parsePhone(String phone) throws ParseException {
@@ -70,6 +78,8 @@ public class ParserUtil {
      * Parses a {@code String address} into an {@code Address}.
      * Leading and trailing whitespaces will be trimmed.
      *
+     * @param address the address
+     * @return the address
      * @throws ParseException if the given {@code address} is invalid.
      */
     public static Address parseAddress(String address) throws ParseException {
@@ -85,6 +95,8 @@ public class ParserUtil {
      * Parses a {@code String birthday} into a {@code Birthday}.
      * Leading and trailing whitespaces will be trimmed.
      *
+     * @param birthday the birthday
+     * @return the birthday
      * @throws ParseException if the given {@code birthday} is invalid.
      */
     public static Birthday parseBirthday(String birthday) throws ParseException {
@@ -100,6 +112,8 @@ public class ParserUtil {
      * Parses a {@code String email} into an {@code Email}.
      * Leading and trailing whitespaces will be trimmed.
      *
+     * @param email the email
+     * @return the email
      * @throws ParseException if the given {@code email} is invalid.
      */
     public static Email parseEmail(String email) throws ParseException {
@@ -115,6 +129,8 @@ public class ParserUtil {
      * Parses a {@code String tag} into a {@code Tag}.
      * Leading and trailing whitespaces will be trimmed.
      *
+     * @param tag the tag
+     * @return the tag
      * @throws ParseException if the given {@code tag} is invalid.
      */
     public static Tag parseTag(String tag) throws ParseException {
@@ -136,5 +152,27 @@ public class ParserUtil {
             tagSet.add(parseTag(tagName));
         }
         return tagSet;
+    }
+
+    /**
+     * Parses {@code String policyName} and {@code String policyId} into a {@code Policy}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @param policyName the name
+     * @param policyID the id
+     * @return the policy
+     * @throws ParseException if the given {@code policyName} or {@code policyId} is invalid.
+     */
+    public static Policy parsePolicyInfo(String policyName, String policyID) throws ParseException {
+        requireNonNull(policyName, policyID);
+        String trimmedPolicyName = policyName.trim();
+        String trimmedPolicyID = policyID.trim();
+        if (!Policy.isValidName(trimmedPolicyName)) {
+            throw new ParseException(Policy.MESSAGE_CONSTRAINTS_NAME);
+        }
+        if (!Policy.isValidID(trimmedPolicyID)) {
+            throw new ParseException(Policy.MESSAGE_CONSTRAINTS_ID);
+        }
+        return new Policy(trimmedPolicyName, trimmedPolicyID);
     }
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -12,6 +12,8 @@ import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.PolicyList;
+import seedu.address.model.policy.Policy;
 
 /**
  * Represents the in-memory model of the address book data.
@@ -109,6 +111,21 @@ public class ModelManager implements Model {
         requireAllNonNull(target, editedPerson);
 
         addressBook.setPerson(target, editedPerson);
+    }
+
+    /**
+     * Add policy to person.
+     *
+     * @param target the target
+     * @param policy the policy
+     */
+    public void addPolicy(Person target, Policy policy) {
+        requireAllNonNull(target, policy);
+        PolicyList newPolicyList = target.getPolicyList().getPolicyListClone();
+        newPolicyList.addPolicy(policy);
+        setPerson(target, new Person(target.getName(), target.getPhone(), target.getEmail(), target.getAddress(),
+                target.getBirthday(), target.getLastMet(), target.getSchedule(), target.getTags(),
+                newPolicyList));
     }
 
     //=========== Filtered Person List Accessors =============================================================

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -10,6 +10,7 @@ import java.util.Objects;
 import java.util.Set;
 
 import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.model.policy.Policy;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -29,6 +30,7 @@ public class Person {
     private final LastMet lastMet;
     private final Schedule schedule;
     private final Set<Tag> tags = new HashSet<>();
+    private final PolicyList policyList;
 
     /**
      * Every field must be present and not null.
@@ -43,14 +45,15 @@ public class Person {
         this.lastMet = new LastMet(LocalDate.now());
         this.schedule = new Schedule(LocalDateTime.now(), true);
         this.tags.addAll(tags);
+        this.policyList = new PolicyList();
     }
 
     /**
      * Person constructor used for subsequent LastMet, Schedule and Mark Commands.
      */
     public Person(Name name, Phone phone, Email email, Address address, Birthday birthday,
-                  LastMet lastmet, Schedule schedule, Set<Tag> tags) {
-        requireAllNonNull(name, phone, email, address, birthday, tags);
+                  LastMet lastmet, Schedule schedule, Set<Tag> tags, PolicyList policyList) {
+        requireAllNonNull(name, phone, email, address, birthday, tags, policyList);
         this.name = name;
         this.phone = phone;
         this.email = email;
@@ -59,6 +62,7 @@ public class Person {
         this.lastMet = checkNullLastMet(lastmet);
         this.schedule = checkNullSchedule(schedule);
         this.tags.addAll(tags);
+        this.policyList = policyList;
     }
 
     public Name getName() {
@@ -87,6 +91,9 @@ public class Person {
 
     public Schedule getSchedule() {
         return schedule;
+    }
+    public PolicyList getPolicyList() {
+        return policyList;
     }
 
     private LastMet checkNullLastMet(LastMet lastmet) {
@@ -127,6 +134,17 @@ public class Person {
     }
 
     /**
+     * Has policy id boolean.
+     *
+     * @param policy the policy
+     * @return the boolean
+     */
+    public boolean hasPolicyID(Policy policy) {
+        return policyList.hasPolicyID(policy);
+    }
+
+
+    /**
      * Returns true if both persons have the same identity and data fields.
      * This defines a stronger notion of equality between two persons.
      */
@@ -147,7 +165,8 @@ public class Person {
                 && email.equals(otherPerson.email)
                 && address.equals(otherPerson.address)
                 && birthday.equals(otherPerson.birthday)
-                && tags.equals(otherPerson.tags);
+                && tags.equals(otherPerson.tags)
+                && policyList.equals(otherPerson.policyList);
     }
 
     @Override
@@ -165,6 +184,7 @@ public class Person {
                 .add("address", address)
                 .add("birthday", birthday)
                 .add("tags", tags)
+                .add("policies", policyList)
                 .toString();
     }
 

--- a/src/main/java/seedu/address/model/person/PolicyList.java
+++ b/src/main/java/seedu/address/model/person/PolicyList.java
@@ -1,0 +1,118 @@
+package seedu.address.model.person;
+
+import java.util.ArrayList;
+import java.util.stream.Stream;
+
+import seedu.address.model.person.exceptions.PolicyNotFoundException;
+import seedu.address.model.policy.Policy;
+
+
+/**
+ * The type Policy list.
+ */
+public class PolicyList {
+    /**
+     * The Policy list.
+     */
+    public final ArrayList<Policy> policyList;
+
+    /**
+     * Instantiates a new Policy list.
+     */
+    public PolicyList() {
+        this.policyList = new ArrayList<Policy>();
+    }
+
+    /**
+     * Instantiates a new Policy list.
+     *
+     * @param policyList the policy list
+     */
+    public PolicyList(ArrayList<Policy> policyList) {
+        this.policyList = policyList;
+    }
+
+    /**
+     * Add policy.
+     *
+     * @param newPolicy the new policy
+     */
+    public void addPolicy(Policy newPolicy) {
+        policyList.add(newPolicy);
+    }
+
+    /**
+     * Delete policy.
+     *
+     * @param policyId the policy id
+     * @throws PolicyNotFoundException the policy not found exception
+     */
+    public void deletePolicy(String policyId) throws PolicyNotFoundException {
+        Policy toDelete = findPolicy(policyId);
+        policyList.remove(toDelete);
+    }
+    private Policy findPolicy(String policyId) throws PolicyNotFoundException {
+        for (Policy p: policyList) {
+            if (p.isID(policyId)) {
+                return p;
+            }
+        }
+        throw new PolicyNotFoundException();
+    }
+
+    /**
+     * Has policy id boolean.
+     *
+     * @param newPolicy the new policy
+     * @return the boolean
+     */
+    public boolean hasPolicyID(Policy newPolicy) {
+        boolean isConflicting = false;
+        for (Policy p: policyList) {
+            if (p.hasSameID(newPolicy)) {
+                isConflicting = true;
+                break;
+            }
+        }
+        return isConflicting;
+    }
+
+    /**
+     * To stream stream.
+     *
+     * @return the stream
+     */
+    public Stream<Policy> toStream() {
+        return policyList.stream();
+    }
+
+    /**
+     * Gets policy list clone.
+     *
+     * @return the policy list clone
+     */
+    public PolicyList getPolicyListClone() {
+        @SuppressWarnings("unchecked")
+        // cloneArraylist is a clone of policyList and can be safely typecasted
+        ArrayList<Policy> cloneArraylist = (ArrayList<Policy>) policyList.clone();
+        return new PolicyList(cloneArraylist);
+    }
+
+    public String toString() {
+        return policyList.toString();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+
+        if (!(other instanceof PolicyList)) {
+            return false;
+        }
+
+        PolicyList otherPolicyList = (PolicyList) other;
+        return policyList.equals(otherPolicyList.policyList);
+    }
+}

--- a/src/main/java/seedu/address/model/person/exceptions/PolicyNotFoundException.java
+++ b/src/main/java/seedu/address/model/person/exceptions/PolicyNotFoundException.java
@@ -1,0 +1,6 @@
+package seedu.address.model.person.exceptions;
+
+/**
+ * Signals that the operation is unable to find the specified policy.
+ */
+public class PolicyNotFoundException extends RuntimeException {}

--- a/src/main/java/seedu/address/model/policy/Policy.java
+++ b/src/main/java/seedu/address/model/policy/Policy.java
@@ -1,0 +1,111 @@
+package seedu.address.model.policy;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
+/**
+ * The type Policy.
+ */
+public class Policy {
+    /**
+     * The constant MESSAGE_CONSTRAINTS_NAME.
+     */
+    public static final String MESSAGE_CONSTRAINTS_NAME =
+            "Policy names should only contain alphanumeric characters and spaces, and it should not be blank";
+    /**
+     * The constant MESSAGE_CONSTRAINTS_ID.
+     */
+    public static final String MESSAGE_CONSTRAINTS_ID =
+            "Policy ID should only contain numbers, and it should be at least 1 digits long";
+    /**
+     * The constant VALIDATION_NAME_REGEX.
+     */
+    public static final String VALIDATION_NAME_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    /**
+     * The constant VALIDATION_ID_REGEX.
+     */
+    public static final String VALIDATION_ID_REGEX = "\\d+";
+    /**
+     * The Policy name.
+     */
+    public final String policyName;
+    /**
+     * The Policy id.
+     */
+    public final String policyID;
+    private final PolicyType type;
+
+
+    /**
+     * Instantiates a new Policy.
+     *
+     * @param policyName the policy name
+     * @param policyID   the policy id
+     */
+    public Policy(String policyName, String policyID) {
+        requireNonNull(policyName, policyID);
+        checkArgument(isValidName(policyName), MESSAGE_CONSTRAINTS_NAME);
+        checkArgument(isValidID(policyID), MESSAGE_CONSTRAINTS_ID);
+        this.policyName = policyName;
+        this.policyID = policyID;
+        this.type = PolicyType.DEFAULT;
+    }
+
+    /**
+     * Is id boolean.
+     *
+     * @param testID the test id
+     * @return the boolean
+     */
+    public boolean isID(String testID) {
+        return testID.equals(policyID);
+    }
+
+    /**
+     * Is valid name boolean.
+     *
+     * @param test the test
+     * @return the boolean
+     */
+    public static boolean isValidName(String test) {
+        return test.matches(VALIDATION_NAME_REGEX);
+    }
+
+    /**
+     * Is valid id boolean.
+     *
+     * @param test the test
+     * @return the boolean
+     */
+    public static boolean isValidID(String test) {
+        return test.matches(VALIDATION_ID_REGEX);
+    }
+
+    /**
+     * Has same id boolean.
+     *
+     * @param policy the policy
+     * @return the boolean
+     */
+    public boolean hasSameID(Policy policy) {
+        return policyID.equals(policy.policyID);
+    }
+    @Override
+    public String toString() {
+        return "Name:" + policyName + ", Type:" + type + ", Policy ID:" + policyID;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+
+        if (!(obj instanceof Policy)) {
+            return false;
+        }
+
+        Policy policy = (Policy) obj;
+        return policyID.equals(policy.policyID) && policyName.equals(policy.policyName);
+    }
+}

--- a/src/main/java/seedu/address/model/policy/PolicyType.java
+++ b/src/main/java/seedu/address/model/policy/PolicyType.java
@@ -1,0 +1,12 @@
+package seedu.address.model.policy;
+
+enum PolicyType {
+    HEALTH,
+    PERSONAL_ACCIDENT,
+    LIFE,
+    TRAVEL,
+    HOME,
+    CAR,
+    SAVING,
+    DEFAULT
+}

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -1,5 +1,7 @@
 package seedu.address.model.util;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -9,9 +11,13 @@ import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Birthday;
 import seedu.address.model.person.Email;
+import seedu.address.model.person.LastMet;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.PolicyList;
+import seedu.address.model.person.Schedule;
+import seedu.address.model.policy.Policy;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -22,7 +28,8 @@ public class SampleDataUtil {
         return new Person[] {
             new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
                 new Address("Blk 30 Geylang Street 29, #06-40"), new Birthday("1990-01-01"),
-                getTagSet("friends")),
+                new LastMet(LocalDate.now()), new Schedule(LocalDateTime.now().plusMonths(1)),
+                getTagSet("friends"), getPoliciesSet("Health,001", "Travel,002")),
             new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
                 new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"), new Birthday("1983-03-15"),
                 getTagSet("colleagues", "friends")),
@@ -56,6 +63,13 @@ public class SampleDataUtil {
         return Arrays.stream(strings)
                 .map(Tag::new)
                 .collect(Collectors.toSet());
+    }
+
+    public static PolicyList getPoliciesSet(String... strings) {
+        PolicyList policies = new PolicyList();
+        Arrays.stream(strings).forEach(x -> policies.addPolicy(new Policy(x.split(",")[0],
+                x.split(",")[1])));
+        return policies;
     }
 
 }

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -19,6 +19,7 @@ import seedu.address.model.person.LastMet;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.PolicyList;
 import seedu.address.model.person.Schedule;
 import seedu.address.model.tag.Tag;
 
@@ -37,6 +38,7 @@ class JsonAdaptedPerson {
     private final String lastmet;
     private final String schedule;
     private final List<JsonAdaptedTag> tags = new ArrayList<>();
+    private final List<JsonAdaptedPolicy> policies = new ArrayList<>();
 
     /**
      * Constructs a {@code JsonAdaptedPerson} with the given person details.
@@ -45,8 +47,8 @@ class JsonAdaptedPerson {
     public JsonAdaptedPerson(@JsonProperty("name") String name, @JsonProperty("phone") String phone,
             @JsonProperty("email") String email, @JsonProperty("address") String address,
             @JsonProperty("birthday") String birthday, @JsonProperty("lastmet") String lastmet,
-                             @JsonProperty("schedule") String schedule,
-                             @JsonProperty("tags") List<JsonAdaptedTag> tags) {
+            @JsonProperty("schedule") String schedule, @JsonProperty("tags") List<JsonAdaptedTag> tags,
+            @JsonProperty("policies") List<JsonAdaptedPolicy> policies) {
         this.name = name;
         this.phone = phone;
         this.email = email;
@@ -56,6 +58,9 @@ class JsonAdaptedPerson {
         this.schedule = schedule;
         if (tags != null) {
             this.tags.addAll(tags);
+        }
+        if (policies != null) {
+            this.policies.addAll(policies);
         }
     }
 
@@ -73,6 +78,9 @@ class JsonAdaptedPerson {
         tags.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)
                 .collect(Collectors.toList()));
+        policies.addAll(source.getPolicyList().toStream()
+                .map(JsonAdaptedPolicy::new)
+                .collect(Collectors.toList()));
     }
 
     /**
@@ -82,8 +90,14 @@ class JsonAdaptedPerson {
      */
     public Person toModelType() throws IllegalValueException {
         final List<Tag> personTags = new ArrayList<>();
+        final PolicyList personPolicies = new PolicyList();
+
         for (JsonAdaptedTag tag : tags) {
             personTags.add(tag.toModelType());
+        }
+
+        for (JsonAdaptedPolicy policy : policies) {
+            personPolicies.addPolicy(policy.toModelType());
         }
 
         if (name == null) {
@@ -137,7 +151,7 @@ class JsonAdaptedPerson {
 
         final Set<Tag> modelTags = new HashSet<>(personTags);
         return new Person(modelName, modelPhone, modelEmail, modelAddress, modelBirthday,
-                modelLastMet, modelSchedule, modelTags);
+                modelLastMet, modelSchedule, modelTags, personPolicies);
     }
 
 }

--- a/src/main/java/seedu/address/storage/JsonAdaptedPolicy.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPolicy.java
@@ -1,0 +1,55 @@
+package seedu.address.storage;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.policy.Policy;
+
+/**
+ * Jackson-friendly version of {@link Policy}.
+ */
+class JsonAdaptedPolicy {
+
+    private final String policyName;
+    private final String policyID;
+
+    /**
+     * Constructs a {@code JsonAdaptedPolicy} with the given {@code policyName, policyID}.
+     */
+    @JsonCreator
+    public JsonAdaptedPolicy(String policyDetails) {
+        String[] args = policyDetails.split(",");
+        this.policyName = args[0];
+        this.policyID = args[1];
+    }
+
+    /**
+     * Converts a given {@code Policy} into this class for Jackson use.
+     */
+    public JsonAdaptedPolicy(Policy source) {
+        policyName = source.policyName;
+        policyID = source.policyID;
+    }
+
+    @JsonValue
+    public String getPolicyDetails() {
+        return policyName + "," + policyID;
+    }
+
+    /**
+     * Converts this Jackson-friendly adapted policy object into the model's {@code Policy} object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated in the adapted policy.
+     */
+    public Policy toModelType() throws IllegalValueException {
+        if (!Policy.isValidName(policyName)) {
+            throw new IllegalValueException(Policy.MESSAGE_CONSTRAINTS_NAME);
+        }
+        if (!Policy.isValidID(policyID)) {
+            throw new IllegalValueException(Policy.MESSAGE_CONSTRAINTS_ID);
+        }
+        return new Policy(policyName, policyID);
+    }
+
+}

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -17,7 +17,8 @@
     "birthday": "1998-12-03",
     "lastmet": "2023-01-02",
     "schedule": "2023-02-02 12:14/0",
-    "tags" : [ "owesMoney", "friends" ]
+    "tags" : [ "owesMoney", "friends" ],
+    "policies" : [ "Health,123", "Travel,456" ]
   }, {
     "name" : "Carl Kurz",
     "phone" : "95352563",

--- a/src/test/java/seedu/address/logic/commands/AddPolicyCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddPolicyCommandTest.java
@@ -1,0 +1,130 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.AddPolicyCommand.MESSAGE_SUCCESS;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.policy.Policy;
+
+public class AddPolicyCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void equals() {
+        Index index = Index.fromOneBased(1);
+        AddPolicyCommand addPolicyCommand = new AddPolicyCommand(index, new Policy("Life", "123"));
+        AddPolicyCommand sameAddPolicyCommand = new AddPolicyCommand(index, new Policy("Life", "123"));
+
+        assertTrue(addPolicyCommand.equals(addPolicyCommand));
+        assertTrue(addPolicyCommand.equals(sameAddPolicyCommand));
+        assertFalse(addPolicyCommand.equals(null));
+        assertFalse(addPolicyCommand.equals(new Object()));
+        assertFalse(addPolicyCommand.equals(new AddPolicyCommand(Index.fromOneBased(2),
+                new Policy("Life", "123"))));
+        assertFalse(addPolicyCommand.equals(new AddPolicyCommand(Index.fromOneBased(1),
+                new Policy("Health", "123"))));
+        assertFalse(addPolicyCommand.equals(new AddPolicyCommand(Index.fromOneBased(1),
+                new Policy("Life", "113"))));
+    }
+
+    @Test
+    public void execute_validIndexAndPolicyID_success() {
+        Index validIndex = Index.fromOneBased(1);
+        Policy policyToAdd = new Policy("Life", "123");
+        AddPolicyCommand addPolicyCommand = new AddPolicyCommand(validIndex, policyToAdd);
+
+        ModelManager expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.addPolicy(model.getAddressBook().getPersonList().get(0), policyToAdd);
+
+        CommandTestUtil.assertCommandSuccess(addPolicyCommand, model,
+                String.format(MESSAGE_SUCCESS, model.getFilteredPersonList().get(0).getName()), expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndex_throwsCommandException() {
+        Index invalidIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        Policy policyToAdd = new Policy("Life", "123");
+
+        AddPolicyCommand addPolicyCommand = new AddPolicyCommand(invalidIndex, policyToAdd);
+
+        assertThrows(CommandException.class, () -> addPolicyCommand.execute(model),
+                Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_conflictingId_throwsCommandException() {
+        Index validIndex = Index.fromOneBased(1);
+        Policy policyToAdd = new Policy("Life", "123");
+        Policy conflictingPolicyToAdd = new Policy("Health", "123");
+
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.addPolicy(model.getAddressBook().getPersonList().get(0), policyToAdd);
+
+        AddPolicyCommand firstAddPolicyCommand = new AddPolicyCommand(validIndex, policyToAdd);
+        AddPolicyCommand secondAddPolicyCommand = new AddPolicyCommand(validIndex, conflictingPolicyToAdd);
+
+        CommandTestUtil.assertCommandSuccess(firstAddPolicyCommand, model,
+                String.format(MESSAGE_SUCCESS, model.getFilteredPersonList().get(0).getName()), expectedModel);
+
+        assertThrows(CommandException.class, () -> secondAddPolicyCommand.execute(model),
+                Messages.MESSAGE_DUPLICATE_POLICY);
+    }
+
+    @Test
+    public void execute_validIndexFilteredList_success() {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+
+        Index validIndex = Index.fromOneBased(1);
+        Policy policyToAdd = new Policy("Life", "123");
+        AddPolicyCommand addPolicyCommand = new AddPolicyCommand(validIndex, policyToAdd);
+
+
+        ModelManager expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.addPolicy(model.getAddressBook().getPersonList().get(0), policyToAdd);
+
+        CommandTestUtil.assertCommandSuccess(addPolicyCommand, model,
+                String.format(MESSAGE_SUCCESS, model.getFilteredPersonList().get(0).getName()), expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexFilteredList_throwsCommandException() {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+
+        Index outOfBoundIndex = INDEX_SECOND_PERSON;
+        // ensures that outOfBoundIndex is still in bounds of address book list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
+
+        Policy policyToAdd = new Policy("Life", "123");
+        AddPolicyCommand addPolicyCommand = new AddPolicyCommand(outOfBoundIndex, policyToAdd);
+
+        assertCommandFailure(addPolicyCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void toString_validCommand_returnsExpectedString() {
+        Index index = Index.fromOneBased(1);
+        Policy policyToAdd = new Policy("Life", "123");
+        AddPolicyCommand addPolicyCommand = new AddPolicyCommand(index, policyToAdd);
+        String expected = AddPolicyCommand.class.getCanonicalName() + "{index=" + index + ", addPolicy="
+                + policyToAdd + "}";
+        assertEquals(expected, addPolicyCommand.toString());
+    }
+}
+

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -39,6 +39,7 @@ public class CommandTestUtil {
     public static final String VALID_BIRTHDAY_BOB = "1978-11-03";
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";
+    public static final String VALID_POLICY_LIFE = "Life,1";
 
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;

--- a/src/test/java/seedu/address/logic/parser/AddPolicyCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddPolicyCommandParserTest.java
@@ -1,0 +1,66 @@
+package seedu.address.logic.parser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_POLICYID;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_POLICYNAME;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.AddPolicyCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.policy.Policy;
+public class AddPolicyCommandParserTest {
+
+    private final AddPolicyCommandParser parser = new AddPolicyCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsAddPolicyCommand() throws ParseException {
+        String args = "1 " + PREFIX_POLICYNAME + "Life " + PREFIX_POLICYID + "123";
+        Policy policyToAdd = new Policy("Life", "123");
+        AddPolicyCommand expectedCommand = new AddPolicyCommand(ParserUtil.parseIndex("1"), policyToAdd);
+        assertEquals(expectedCommand, parser.parse(args));
+    }
+
+    @Test
+    public void parse_missingIndex_throwsParseException() {
+        // Missing index
+        String args = PREFIX_POLICYNAME + "Life " + PREFIX_POLICYID + "123";
+        assertThrows(ParseException.class, () -> parser.parse(args));
+    }
+
+    @Test
+    public void parse_missingPolicyNamePrefix_throwsParseException() {
+        // Missing policyName prefix
+        String args = "1 Life " + PREFIX_POLICYID + "123";
+        assertThrows(ParseException.class, () -> parser.parse(args));
+    }
+
+    @Test
+    public void parse_missingPolicyIdPrefix_throwsParseException() {
+        // Missing policyId prefix
+        String args = "1 " + PREFIX_POLICYNAME + "Life 123";
+        assertThrows(ParseException.class, () -> parser.parse(args));
+    }
+
+    @Test
+    public void parse_invalidIndexFormat_throwsParseException() {
+        // Invalid index format
+        String args = "invalid " + PREFIX_POLICYNAME + "Life " + PREFIX_POLICYID + "123";
+        assertThrows(ParseException.class, () -> parser.parse(args));
+    }
+
+    @Test
+    public void parse_invalidPolicyNameFormat_throwsParseException() {
+        // Invalid policyName format
+        String args = "1 " + PREFIX_POLICYNAME + "#Life " + PREFIX_POLICYID + "123";
+        assertThrows(ParseException.class, () -> parser.parse(args));
+    }
+
+    @Test
+    public void parse_invalidPolicyIdFormat_throwsParseException() {
+        // Invalid policyId format
+        String args = "1 " + PREFIX_POLICYNAME + "Life " + PREFIX_POLICYID + "a123";
+        assertThrows(ParseException.class, () -> parser.parse(args));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -14,6 +14,7 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.AddPolicyCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
@@ -25,6 +26,7 @@ import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
+import seedu.address.model.policy.Policy;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
 import seedu.address.testutil.PersonUtil;
@@ -86,6 +88,14 @@ public class AddressBookParserTest {
     public void parseCommand_list() throws Exception {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
+    }
+
+    @Test
+    public void parseCommand_addPolicy() throws Exception {
+        AddPolicyCommand command = (AddPolicyCommand) parser.parseCommand(
+                AddPolicyCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased()
+                        + " n/Health i/123");
+        assertEquals(new AddPolicyCommand(INDEX_FIRST_PERSON, new Policy("Health", "123")), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -18,6 +18,7 @@ import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
+import seedu.address.model.policy.Policy;
 import seedu.address.model.tag.Tag;
 
 public class ParserUtilTest {
@@ -26,6 +27,9 @@ public class ParserUtilTest {
     private static final String INVALID_ADDRESS = " ";
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_TAG = "#friend";
+    private static final String INVALID_POLICYNAME = "#Life";
+    private static final String INVALID_POLICYID = "#123";
+
 
     private static final String VALID_NAME = "Rachel Walker";
     private static final String VALID_PHONE = "123456";
@@ -33,6 +37,9 @@ public class ParserUtilTest {
     private static final String VALID_EMAIL = "rachel@example.com";
     private static final String VALID_TAG_1 = "friend";
     private static final String VALID_TAG_2 = "neighbour";
+
+    private static final String VALID_POLICYNAME = "Life";
+    private static final String VALID_POLICYID = "123";
 
     private static final String WHITESPACE = " \t\r\n";
 
@@ -192,5 +199,45 @@ public class ParserUtilTest {
         Set<Tag> expectedTagSet = new HashSet<Tag>(Arrays.asList(new Tag(VALID_TAG_1), new Tag(VALID_TAG_2)));
 
         assertEquals(expectedTagSet, actualTagSet);
+    }
+
+    @Test
+    public void parsePolicyInfo_nullPolicyName_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parsePolicyInfo((String) null, VALID_POLICYID));
+    }
+
+    @Test
+    public void parsePolicyInfo_nullPolicyId_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parsePolicyInfo(VALID_POLICYNAME, (String) null));
+    }
+
+    @Test
+    public void parsePolicyInfo_invalidValuePolicyName_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parsePolicyInfo(INVALID_POLICYNAME, VALID_POLICYID));
+    }
+
+    @Test
+    public void parsePolicyInfo_invalidValuePolicyId_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parsePolicyInfo(VALID_POLICYNAME, INVALID_POLICYID));
+    }
+
+    @Test
+    public void parsePolicyInfo_validValueWithoutWhitespace_returnsPolicy() throws Exception {
+        Policy expectedPolicy = new Policy(VALID_POLICYNAME, VALID_POLICYID);
+        assertEquals(expectedPolicy, ParserUtil.parsePolicyInfo(VALID_POLICYNAME, VALID_POLICYID));
+    }
+
+    @Test
+    public void parsePolicyInfo_validValueWithWhitespacePolicyName_returnsTrimmedPolicy() throws Exception {
+        String policyNameWithWhitespace = WHITESPACE + VALID_POLICYNAME + WHITESPACE;
+        Policy expectedPolicy = new Policy(VALID_POLICYNAME, VALID_POLICYID);
+        assertEquals(expectedPolicy, ParserUtil.parsePolicyInfo(policyNameWithWhitespace, VALID_POLICYID));
+    }
+
+    @Test
+    public void parsePolicyInfo_validValueWithWhitespacePolicyID_returnsTrimmedPolicy() throws Exception {
+        String policyIdWithWhitespace = WHITESPACE + VALID_POLICYID + WHITESPACE;
+        Policy expectedPolicy = new Policy(VALID_POLICYNAME, VALID_POLICYID);
+        assertEquals(expectedPolicy, ParserUtil.parsePolicyInfo(VALID_POLICYNAME, policyIdWithWhitespace));
     }
 }

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -7,6 +7,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_POLICY_LIFE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE;
@@ -92,13 +93,18 @@ public class PersonTest {
         // different tags -> returns false
         editedAlice = new PersonBuilder(ALICE).withTags(VALID_TAG_HUSBAND).build();
         assertFalse(ALICE.equals(editedAlice));
+
+        //differnt policies -> return false
+        editedAlice = new PersonBuilder(ALICE).withPolicies(VALID_POLICY_LIFE).build();
+        assertFalse(ALICE.equals(editedAlice));
     }
 
     @Test
     public void toStringMethod() {
         String expected = Person.class.getCanonicalName() + "{name=" + ALICE.getName() + ", phone=" + ALICE.getPhone()
                 + ", email=" + ALICE.getEmail() + ", address=" + ALICE.getAddress()
-                + ", birthday=" + ALICE.getBirthday() + ", tags=" + ALICE.getTags() + "}";
+                + ", birthday=" + ALICE.getBirthday() + ", tags=" + ALICE.getTags() + ", policies="
+                + ALICE.getPolicyList() + "}";
         assertEquals(expected, ALICE.toString());
     }
 }

--- a/src/test/java/seedu/address/model/policy/PolicyListTest.java
+++ b/src/test/java/seedu/address/model/policy/PolicyListTest.java
@@ -1,0 +1,73 @@
+package seedu.address.model.policy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.person.PolicyList;
+
+public class PolicyListTest {
+    private static final Policy policy1 = new Policy("Life", "1");
+    private static final Policy policy2 = new Policy("Health", "2");
+    private static final Policy policy3 = new Policy("Travel", "3");
+    private static final Policy policy4 = new Policy("Saving", "4");
+
+    @Test
+    public void addPolicy() {
+        ArrayList<Policy> policyArrayList = new ArrayList<>();
+        policyArrayList.add(policy1);
+        policyArrayList.add(policy2);
+        policyArrayList.add(policy3);
+        ArrayList<Policy> differentArrayList = (ArrayList<Policy>) policyArrayList.clone();
+        PolicyList actualPolicyList = new PolicyList(policyArrayList);
+        actualPolicyList.addPolicy(policy4);
+        differentArrayList.add(policy4);
+        assertEquals(actualPolicyList.policyList, differentArrayList);
+    }
+
+    @Test
+    public void hasPolicyID() {
+        ArrayList<Policy> policyArrayList = new ArrayList<>();
+        policyArrayList.add(policy1);
+        policyArrayList.add(policy2);
+        policyArrayList.add(policy3);
+        PolicyList actualPolicyList = new PolicyList(policyArrayList);
+
+        assertTrue(actualPolicyList.hasPolicyID(policy2));
+        assertFalse(actualPolicyList.hasPolicyID(policy4));
+    }
+
+    @Test
+    public void getPolicyListClone() {
+        ArrayList<Policy> policyArrayList = new ArrayList<>();
+        policyArrayList.add(policy1);
+        policyArrayList.add(policy2);
+        policyArrayList.add(policy3);
+        PolicyList actualPolicyList = new PolicyList(policyArrayList);
+        assertEquals(actualPolicyList, actualPolicyList.getPolicyListClone());
+    }
+
+    @Test
+    public void equals() {
+        ArrayList<Policy> policyArrayList = new ArrayList<>();
+        policyArrayList.add(policy1);
+        policyArrayList.add(policy2);
+        policyArrayList.add(policy3);
+        PolicyList policyList = new PolicyList(policyArrayList);
+        PolicyList copyPolicyList = new PolicyList((ArrayList<Policy>) policyArrayList.clone());
+        ArrayList<Policy> differentArrayList = (ArrayList<Policy>) policyArrayList.clone();
+        differentArrayList.add(policy4);
+        PolicyList differentPolicyList = new PolicyList(differentArrayList);
+
+        assertTrue(policyList.equals(policyList));
+        assertTrue(policyList.equals(copyPolicyList));
+        assertFalse(policyList.equals(null));
+        assertFalse(policyList.equals(5));
+        assertFalse(policyList.equals(differentPolicyList));
+    }
+
+}

--- a/src/test/java/seedu/address/model/policy/PolicyTest.java
+++ b/src/test/java/seedu/address/model/policy/PolicyTest.java
@@ -1,0 +1,76 @@
+package seedu.address.model.policy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class PolicyTest {
+    private static final String VALID_NAME = "Life";
+    private static final String VALID_ID = "123";
+    private static final String INVALID_NAME = "#Life";
+    private static final String INVALID_ID = "#123";
+
+    private static final Policy policy = new Policy(VALID_NAME, VALID_ID);
+
+    @Test
+    public void isIdTestTrue() {
+        assertTrue(policy.isID(VALID_ID));
+    }
+    @Test
+    public void isIdTestFalse() {
+        assertFalse(policy.isID("124"));
+    }
+
+    @Test
+    public void isValidNameTestTrue() {
+        assertTrue(Policy.isValidName(VALID_NAME));
+    }
+
+    @Test
+    public void isValidNameTestFalse() {
+        assertFalse(Policy.isValidName(INVALID_NAME));
+    }
+
+    @Test
+    public void isValidIdTestTrue() {
+        assertTrue(Policy.isValidID(VALID_ID));
+    }
+
+    @Test
+    public void isValidIdTestFalse() {
+        assertFalse(Policy.isValidID(INVALID_ID));
+    }
+
+    @Test
+    public void hasSameIdTestTrue() {
+        assertTrue(policy.hasSameID(policy));
+    }
+    @Test
+    public void hasSameIdTestFalse() {
+        Policy otherPolicy = new Policy("Health", "456");
+        assertFalse(policy.hasSameID(otherPolicy));
+    }
+
+    @Test
+    public void toStringMethod() {
+        assertEquals(policy.toString(), "Name:" + VALID_NAME + ", Type:DEFAULT, Policy ID:" + VALID_ID);
+    }
+
+    @Test
+    public void equals() {
+        Policy policyCopy = new Policy(VALID_NAME, VALID_ID);
+        Policy differentPolicy = new Policy("Health", "456");
+        Policy sameNameDifferentId = new Policy(VALID_NAME, "456");
+        Policy sameIdDifferentName = new Policy("Health", VALID_ID);
+        assertTrue(policy.equals(policyCopy));
+        assertTrue(policy.equals(policy));
+        assertFalse(policy.equals(null));
+        assertFalse(policy.equals(5));
+        assertFalse(policy.equals(differentPolicy));
+        assertFalse(policy.equals(sameNameDifferentId));
+        assertFalse(policy.equals(sameIdDifferentName));
+
+    }
+}

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -27,6 +27,7 @@ public class JsonAdaptedPersonTest {
     private static final String INVALID_LASTMET = "03-03-2001";
     private static final String INVALID_SCHEDULE = "03-03-2001 12:12/1";
     private static final String INVALID_TAG = "#friend";
+    private static final String INVALID_POLICY = "Health,a123";
 
     private static final String VALID_NAME = BENSON.getName().toString();
     private static final String VALID_PHONE = BENSON.getPhone().toString();
@@ -37,6 +38,9 @@ public class JsonAdaptedPersonTest {
     private static final String VALID_SCHEDULE = BENSON.getSchedule().toString();
     private static final List<JsonAdaptedTag> VALID_TAGS = BENSON.getTags().stream()
             .map(JsonAdaptedTag::new)
+            .collect(Collectors.toList());
+    private static final List<JsonAdaptedPolicy> VALID_POLICIES = BENSON.getPolicyList().toStream()
+            .map(JsonAdaptedPolicy::new)
             .collect(Collectors.toList());
 
     @Test
@@ -49,7 +53,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_BIRTHDAY,
-                        VALID_LASTMET, VALID_SCHEDULE, VALID_TAGS);
+                        VALID_LASTMET, VALID_SCHEDULE, VALID_TAGS, VALID_POLICIES);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -57,7 +61,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                VALID_BIRTHDAY, VALID_LASTMET, VALID_SCHEDULE, VALID_TAGS);
+                VALID_BIRTHDAY, VALID_LASTMET, VALID_SCHEDULE, VALID_TAGS, VALID_POLICIES);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -66,7 +70,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_BIRTHDAY,
-                        VALID_LASTMET, VALID_SCHEDULE, VALID_TAGS);
+                        VALID_LASTMET, VALID_SCHEDULE, VALID_TAGS, VALID_POLICIES);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -74,7 +78,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS,
-                VALID_BIRTHDAY, VALID_LASTMET, VALID_SCHEDULE, VALID_TAGS);
+                VALID_BIRTHDAY, VALID_LASTMET, VALID_SCHEDULE, VALID_TAGS, VALID_POLICIES);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -83,7 +87,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS, VALID_BIRTHDAY,
-                        VALID_LASTMET, VALID_SCHEDULE, VALID_TAGS);
+                        VALID_LASTMET, VALID_SCHEDULE, VALID_TAGS, VALID_POLICIES);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -91,7 +95,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS,
-                VALID_BIRTHDAY, VALID_LASTMET, VALID_SCHEDULE, VALID_TAGS);
+                VALID_BIRTHDAY, VALID_LASTMET, VALID_SCHEDULE, VALID_TAGS, VALID_POLICIES);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -100,7 +104,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidAddress_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS, VALID_BIRTHDAY,
-                        VALID_LASTMET, VALID_SCHEDULE, VALID_TAGS);
+                        VALID_LASTMET, VALID_SCHEDULE, VALID_TAGS, VALID_POLICIES);
         String expectedMessage = Address.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -108,7 +112,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullAddress_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, null,
-                VALID_BIRTHDAY, VALID_LASTMET, VALID_SCHEDULE, VALID_TAGS);
+                VALID_BIRTHDAY, VALID_LASTMET, VALID_SCHEDULE, VALID_TAGS, VALID_POLICIES);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -117,7 +121,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidBirthday_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, INVALID_BIRTHDAY,
-                        VALID_LASTMET, VALID_SCHEDULE, VALID_TAGS);
+                        VALID_LASTMET, VALID_SCHEDULE, VALID_TAGS, VALID_POLICIES);
         String expectedMessage = Birthday.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -125,7 +129,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullBirthday_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                null, VALID_LASTMET, VALID_SCHEDULE, VALID_TAGS);
+                null, VALID_LASTMET, VALID_SCHEDULE, VALID_TAGS, VALID_POLICIES);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Birthday.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -136,7 +140,17 @@ public class JsonAdaptedPersonTest {
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_BIRTHDAY,
-                        VALID_LASTMET, VALID_SCHEDULE, invalidTags);
+                        VALID_LASTMET, VALID_SCHEDULE, invalidTags, VALID_POLICIES);
+        assertThrows(IllegalValueException.class, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidPolicies_throwsIllegalValueException() {
+        List<JsonAdaptedPolicy> invalidPolicies = new ArrayList<>(VALID_POLICIES);
+        invalidPolicies.add(new JsonAdaptedPolicy(INVALID_POLICY));
+        JsonAdaptedPerson person =
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_BIRTHDAY,
+                        VALID_LASTMET, VALID_SCHEDULE, VALID_TAGS, invalidPolicies);
         assertThrows(IllegalValueException.class, person::toModelType);
     }
 

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -9,6 +9,7 @@ import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.PolicyList;
 import seedu.address.model.tag.Tag;
 import seedu.address.model.util.SampleDataUtil;
 
@@ -29,6 +30,7 @@ public class PersonBuilder {
     private Address address;
     private Birthday birthday;
     private Set<Tag> tags;
+    private PolicyList policyList;
 
     /**
      * Creates a {@code PersonBuilder} with the default details.
@@ -40,6 +42,7 @@ public class PersonBuilder {
         address = new Address(DEFAULT_ADDRESS);
         birthday = new Birthday(DEFAULT_BIRTHDAY);
         tags = new HashSet<>();
+        policyList = new PolicyList();
     }
 
     /**
@@ -52,6 +55,7 @@ public class PersonBuilder {
         address = personToCopy.getAddress();
         birthday = personToCopy.getBirthday();
         tags = new HashSet<>(personToCopy.getTags());
+        policyList = personToCopy.getPolicyList();
     }
 
     /**
@@ -102,8 +106,19 @@ public class PersonBuilder {
         return this;
     }
 
+    /**
+     * With policies person builder.
+     *
+     * @param policies the policies
+     * @return the person builder
+     */
+    public PersonBuilder withPolicies(String... policies) {
+        this.policyList = SampleDataUtil.getPoliciesSet(policies);
+        return this;
+    }
+
     public Person build() {
-        return new Person(name, phone, email, address, birthday, tags);
+        return new Person(name, phone, email, address, birthday, null, null, tags, policyList);
     }
 
 }

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -32,7 +32,7 @@ public class TypicalPersons {
     public static final Person BENSON = new PersonBuilder().withName("Benson Meier")
             .withAddress("311, Clementi Ave 2, #02-25").withBirthday("1998-12-03")
             .withEmail("johnd@example.com").withPhone("98765432")
-            .withTags("owesMoney", "friends").build();
+            .withTags("owesMoney", "friends").withPolicies("Health,123", "Travel,456").build();
     public static final Person CARL = new PersonBuilder().withName("Carl Kurz").withPhone("95352563")
             .withEmail("heinz@example.com").withAddress("wall street").withBirthday("1978-05-06").build();
     public static final Person DANIEL = new PersonBuilder().withName("Daniel Meier").withPhone("87652533")


### PR DESCRIPTION
Client policies are not tracked 

Tracking client's policies will allow user to track the client's existing policies. Relates to #44 

Let's
- Add PolicyList, Policy, PolicyType to model
- Enable storage to handle policylist
- Users are to add Policy separately through the addpolicy command
- Update all data for testing and sample data
- Update all test cases for existing files and update for new classes

Follow Up
- Show PolicyList in GUI #67