### PR TITLE
Refactor sorting of person list

### DIFF
--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -69,7 +69,7 @@ public class LogicManager implements Logic {
 
     @Override
     public ObservableList<Person> getFilteredPersonList() {
-        return model.getFilteredPersonList();
+        return model.getSortedFilteredPersonList();
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/AddPolicyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddPolicyCommand.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_POLICYID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_POLICYNAME;
+import static seedu.address.model.Model.COMPARATOR_SHOW_ORIGINAL_ORDER;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.List;
@@ -52,7 +53,7 @@ public class AddPolicyCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        List<Person> lastShownList = model.getFilteredPersonList();
+        List<Person> lastShownList = model.getSortedFilteredPersonList();
 
         if (index.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
@@ -74,6 +75,7 @@ public class AddPolicyCommand extends Command {
 
         model.setPerson(personToAddPolicy, policyAddedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        model.updateSortPersonComparator(COMPARATOR_SHOW_ORIGINAL_ORDER);
         model.setDisplayClient(policyAddedPerson);
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, personToAddPolicy.getName()));

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -34,7 +34,7 @@ public class DeleteCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        List<Person> lastShownList = model.getFilteredPersonList();
+        List<Person> lastShownList = model.getSortedFilteredPersonList();
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);

--- a/src/main/java/seedu/address/logic/commands/DeletePolicyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeletePolicyCommand.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_POLICYID;
+import static seedu.address.model.Model.COMPARATOR_SHOW_ORIGINAL_ORDER;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.List;
@@ -48,7 +49,7 @@ public class DeletePolicyCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        List<Person> lastShownList = model.getFilteredPersonList();
+        List<Person> lastShownList = model.getSortedFilteredPersonList();
 
         if (index.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
@@ -70,6 +71,7 @@ public class DeletePolicyCommand extends Command {
 
         model.setPerson(personToDeletePolicy, policyDeletedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        model.updateSortPersonComparator(COMPARATOR_SHOW_ORIGINAL_ORDER);
         model.setDisplayClient(policyDeletedPerson);
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, policyId, policyDeletedPerson.getName()));

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -8,6 +8,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PRIORITY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.model.Model.COMPARATOR_SHOW_ORIGINAL_ORDER;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.Collections;
@@ -80,7 +81,7 @@ public class EditCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        List<Person> lastShownList = model.getFilteredPersonList();
+        List<Person> lastShownList = model.getSortedFilteredPersonList();
 
         if (index.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
@@ -95,6 +96,7 @@ public class EditCommand extends Command {
 
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        model.updateSortPersonComparator(COMPARATOR_SHOW_ORIGINAL_ORDER);
         model.setDisplayClient(editedPerson);
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson)));
     }

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -30,13 +30,9 @@ public class FindCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.updateFilteredPersonList(predicate);
-        if (model.getFilteredPersonList().isEmpty()) {
-            model.setDisplayClient(null);
-        } else {
-            model.setDisplayClient(model.getFilteredPersonList().get(0));
-        }
+        model.setDisplayClientAsFirstInSortedFilteredPersonList();
         return new CommandResult(
-                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
+                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getSortedFilteredPersonList().size()));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/LastMetCommand.java
+++ b/src/main/java/seedu/address/logic/commands/LastMetCommand.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LASTMET;
+import static seedu.address.model.Model.COMPARATOR_SHOW_ORIGINAL_ORDER;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.time.LocalDate;
@@ -56,7 +57,7 @@ public class LastMetCommand extends Command {
             throw new CommandException(Messages.MESSAGE_LASTMET_FUTURE);
         }
 
-        List<Person> lastShownList = model.getFilteredPersonList();
+        List<Person> lastShownList = model.getSortedFilteredPersonList();
 
         if (index.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
@@ -71,6 +72,7 @@ public class LastMetCommand extends Command {
 
         model.setPerson(personToMeet, metPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        model.updateSortPersonComparator(COMPARATOR_SHOW_ORIGINAL_ORDER);
         model.setDisplayClient(metPerson);
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, personToMeet.getName()));

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.COMPARATOR_SHOW_ORIGINAL_ORDER;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import seedu.address.model.Model;
@@ -19,11 +20,8 @@ public class ListCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        if (model.getFilteredPersonList().isEmpty()) {
-            model.setDisplayClient(null);
-        } else {
-            model.setDisplayClient(model.getFilteredPersonList().get(0));
-        }
+        model.updateSortPersonComparator(COMPARATOR_SHOW_ORIGINAL_ORDER);
+        model.setDisplayClientAsFirstInSortedFilteredPersonList();
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/MarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.COMPARATOR_SHOW_ORIGINAL_ORDER;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.List;
@@ -40,7 +41,7 @@ public class MarkCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        List<Person> lastShownList = model.getFilteredPersonList();
+        List<Person> lastShownList = model.getSortedFilteredPersonList();
 
         if (index.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
@@ -63,6 +64,7 @@ public class MarkCommand extends Command {
         metPerson.getSchedule().markIsDone();
         model.setPerson(personToMeet, metPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        model.updateSortPersonComparator(COMPARATOR_SHOW_ORIGINAL_ORDER);
         model.setDisplayClient(metPerson);
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, personToMeet.getName()));

--- a/src/main/java/seedu/address/logic/commands/RemarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RemarkCommand.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_REMARK;
+import static seedu.address.model.Model.COMPARATOR_SHOW_ORIGINAL_ORDER;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.List;
@@ -48,7 +49,7 @@ public class RemarkCommand extends Command {
     }
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        List<Person> lastShownList = model.getFilteredPersonList();
+        List<Person> lastShownList = model.getSortedFilteredPersonList();
 
         if (index.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
@@ -62,6 +63,7 @@ public class RemarkCommand extends Command {
 
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        model.updateSortPersonComparator(COMPARATOR_SHOW_ORIGINAL_ORDER);
         model.setDisplayClient(editedPerson);
 
         return new CommandResult(generateSuccessMessage(editedPerson));

--- a/src/main/java/seedu/address/logic/commands/ScheduleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ScheduleCommand.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SCHEDULE;
+import static seedu.address.model.Model.COMPARATOR_SHOW_ORIGINAL_ORDER;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.time.LocalDateTime;
@@ -56,7 +57,7 @@ public class ScheduleCommand extends Command {
             throw new CommandException(Messages.MESSAGE_SCHEDULE_PAST);
         }
 
-        List<Person> lastShownList = model.getFilteredPersonList();
+        List<Person> lastShownList = model.getSortedFilteredPersonList();
 
         if (index.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
@@ -71,6 +72,7 @@ public class ScheduleCommand extends Command {
 
         model.setPerson(personToMeet, metPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        model.updateSortPersonComparator(COMPARATOR_SHOW_ORIGINAL_ORDER);
         model.setDisplayClient(metPerson);
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, personToMeet.getName()));

--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -44,7 +44,8 @@ public class SortCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        model.sortFilteredPersonList(PersonComparator.getComparator(sortCriteria, sortOrder));
+        model.updateSortPersonComparator(PersonComparator.getComparator(sortCriteria, sortOrder));
+        model.setDisplayClientAsFirstInSortedFilteredPersonList();
         return new CommandResult(getMessageSuccess(sortCriteria, sortOrder));
     }
 

--- a/src/main/java/seedu/address/logic/commands/ViewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewCommand.java
@@ -36,7 +36,7 @@ public class ViewCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        List<Person> lastShownList = model.getFilteredPersonList();
+        List<Person> lastShownList = model.getSortedFilteredPersonList();
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -16,6 +16,8 @@ public interface Model {
     /** {@code Predicate} that always evaluate to true */
     Predicate<Person> PREDICATE_SHOW_ALL_PERSONS = unused -> true;
 
+    Comparator<Person> COMPARATOR_SHOW_ORIGINAL_ORDER = (person1, person2) -> 0;
+
     /**
      * Replaces user prefs data with the data in {@code userPrefs}.
      */
@@ -79,7 +81,7 @@ public interface Model {
     void setPerson(Person target, Person editedPerson);
 
     /** Returns an unmodifiable view of the filtered person list */
-    ObservableList<Person> getFilteredPersonList();
+    ObservableList<Person> getSortedFilteredPersonList();
 
     /**
      * Updates the filter of the filtered person list to filter by the given {@code predicate}.
@@ -91,7 +93,7 @@ public interface Model {
      * Sorts the filtered person list by the given {@code comparator}.
      * @throws NullPointerException if {@code comparator} is null.
      */
-    void sortFilteredPersonList(Comparator<Person> comparator);
+    void updateSortPersonComparator(Comparator<Person> comparator);
 
     /**
      * Returns the client to be displayed in ClientViewPanel.
@@ -112,6 +114,9 @@ public interface Model {
      * Replaces the current client to be displayed to {@code person}.
      */
     void setDisplayClient(Person person);
+
+    void setDisplayClientAsFirstInSortedFilteredPersonList();
+
     /**
      * Returns the reminder list for the overdue last met to be displayed in RemindersPanel.
      */

--- a/src/main/java/seedu/address/model/person/PersonComparator.java
+++ b/src/main/java/seedu/address/model/person/PersonComparator.java
@@ -1,5 +1,7 @@
 package seedu.address.model.person;
 
+import static seedu.address.model.Model.COMPARATOR_SHOW_ORIGINAL_ORDER;
+
 import java.util.Comparator;
 
 /**
@@ -41,7 +43,7 @@ public class PersonComparator {
             comparator = Comparator.comparing(Person::getSchedule);
             break;
         default:
-            return Comparator.comparing(Person::getName);
+            return COMPARATOR_SHOW_ORIGINAL_ORDER;
         }
         if (sortOrder == SortOrder.DESC) {
             return comparator.reversed();

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -154,7 +154,7 @@ public class AddCommandTest {
         }
 
         @Override
-        public ObservableList<Person> getFilteredPersonList() {
+        public ObservableList<Person> getSortedFilteredPersonList() {
             throw new AssertionError(MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
         }
 
@@ -164,7 +164,7 @@ public class AddCommandTest {
         }
 
         @Override
-        public void sortFilteredPersonList(Comparator<Person> comparator) {
+        public void updateSortPersonComparator(Comparator<Person> comparator) {
             throw new AssertionError(MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
         }
 
@@ -185,6 +185,11 @@ public class AddCommandTest {
 
         @Override
         public void setDisplayClient(Person person) {
+            throw new AssertionError(MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
+        }
+
+        @Override
+        public void setDisplayClientAsFirstInSortedFilteredPersonList() {
             throw new AssertionError(MESSAGE_METHOD_SHOULD_NOT_BE_CALLED);
         }
 

--- a/src/test/java/seedu/address/logic/commands/AddPolicyCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddPolicyCommandTest.java
@@ -54,12 +54,12 @@ public class AddPolicyCommandTest {
         expectedModel.addPolicy(model.getAddressBook().getPersonList().get(0), policyToAdd);
 
         CommandTestUtil.assertCommandSuccess(addPolicyCommand, model,
-                String.format(MESSAGE_SUCCESS, model.getFilteredPersonList().get(0).getName()), expectedModel);
+                String.format(MESSAGE_SUCCESS, model.getSortedFilteredPersonList().get(0).getName()), expectedModel);
     }
 
     @Test
     public void execute_invalidIndex_throwsCommandException() {
-        Index invalidIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        Index invalidIndex = Index.fromOneBased(model.getSortedFilteredPersonList().size() + 1);
         Policy policyToAdd = new Policy("Life", "123");
 
         AddPolicyCommand addPolicyCommand = new AddPolicyCommand(invalidIndex, policyToAdd);
@@ -81,7 +81,7 @@ public class AddPolicyCommandTest {
         AddPolicyCommand secondAddPolicyCommand = new AddPolicyCommand(validIndex, conflictingPolicyToAdd);
 
         CommandTestUtil.assertCommandSuccess(firstAddPolicyCommand, model,
-                String.format(MESSAGE_SUCCESS, model.getFilteredPersonList().get(0).getName()), expectedModel);
+                String.format(MESSAGE_SUCCESS, model.getSortedFilteredPersonList().get(0).getName()), expectedModel);
 
         assertThrows(CommandException.class, () -> secondAddPolicyCommand.execute(model),
                 Messages.MESSAGE_DUPLICATE_POLICY);
@@ -100,7 +100,7 @@ public class AddPolicyCommandTest {
         expectedModel.addPolicy(model.getAddressBook().getPersonList().get(0), policyToAdd);
 
         CommandTestUtil.assertCommandSuccess(addPolicyCommand, model,
-                String.format(MESSAGE_SUCCESS, model.getFilteredPersonList().get(0).getName()), expectedModel);
+                String.format(MESSAGE_SUCCESS, model.getSortedFilteredPersonList().get(0).getName()), expectedModel);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -121,24 +121,24 @@ public class CommandTestUtil {
         // we are unable to defensively copy the model for comparison later, so we can
         // only do so by copying its components.
         AddressBook expectedAddressBook = new AddressBook(actualModel.getAddressBook());
-        List<Person> expectedFilteredList = new ArrayList<>(actualModel.getFilteredPersonList());
+        List<Person> expectedFilteredList = new ArrayList<>(actualModel.getSortedFilteredPersonList());
 
         assertThrows(CommandException.class, expectedMessage, () -> command.execute(actualModel));
         assertEquals(expectedAddressBook, actualModel.getAddressBook());
-        assertEquals(expectedFilteredList, actualModel.getFilteredPersonList());
+        assertEquals(expectedFilteredList, actualModel.getSortedFilteredPersonList());
     }
     /**
      * Updates {@code model}'s filtered list to show only the person at the given {@code targetIndex} in the
      * {@code model}'s address book.
      */
     public static void showPersonAtIndex(Model model, Index targetIndex) {
-        assertTrue(targetIndex.getZeroBased() < model.getFilteredPersonList().size());
+        assertTrue(targetIndex.getZeroBased() < model.getSortedFilteredPersonList().size());
 
-        Person person = model.getFilteredPersonList().get(targetIndex.getZeroBased());
+        Person person = model.getSortedFilteredPersonList().get(targetIndex.getZeroBased());
         final String[] splitName = person.getName().fullName.split("\\s+");
         model.updateFilteredPersonList(new NameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
 
-        assertEquals(1, model.getFilteredPersonList().size());
+        assertEquals(1, model.getSortedFilteredPersonList().size());
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -29,7 +29,7 @@ public class DeleteCommandTest {
 
     @Test
     public void execute_validIndexUnfilteredList_success() {
-        Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person personToDelete = model.getSortedFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS,
@@ -43,7 +43,7 @@ public class DeleteCommandTest {
 
     @Test
     public void execute_invalidIndexUnfilteredList_throwsCommandException() {
-        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        Index outOfBoundIndex = Index.fromOneBased(model.getSortedFilteredPersonList().size() + 1);
         DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
 
         assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
@@ -53,7 +53,7 @@ public class DeleteCommandTest {
     public void execute_validIndexFilteredList_success() {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
 
-        Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person personToDelete = model.getSortedFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS,
@@ -115,6 +115,6 @@ public class DeleteCommandTest {
     private void showNoPerson(Model model) {
         model.updateFilteredPersonList(p -> false);
 
-        assertTrue(model.getFilteredPersonList().isEmpty());
+        assertTrue(model.getSortedFilteredPersonList().isEmpty());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/DeletePolicyCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeletePolicyCommandTest.java
@@ -50,13 +50,13 @@ public class DeletePolicyCommandTest {
         expectedModel.deletePolicy(model.getAddressBook().getPersonList().get(1), policyToDelete);
 
         CommandTestUtil.assertCommandSuccess(deletePolicyCommand, model,
-                String.format(MESSAGE_SUCCESS, policyToDelete, model.getFilteredPersonList().get(1).getName()),
+                String.format(MESSAGE_SUCCESS, policyToDelete, model.getSortedFilteredPersonList().get(1).getName()),
                 expectedModel);
     }
 
     @Test
     public void execute_invalidIndex_throwsCommandException() {
-        Index invalidIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        Index invalidIndex = Index.fromOneBased(model.getSortedFilteredPersonList().size() + 1);
         String policyToDelete = "123";
 
         DeletePolicyCommand deletePolicyCommand = new DeletePolicyCommand(invalidIndex, policyToDelete);
@@ -76,7 +76,7 @@ public class DeletePolicyCommandTest {
         DeletePolicyCommand deletePolicyCommand = new DeletePolicyCommand(validIndex, "123");
 
         CommandTestUtil.assertCommandSuccess(deletePolicyCommand, model,
-                String.format(MESSAGE_SUCCESS, policyToDelete, model.getFilteredPersonList().get(1).getName()),
+                String.format(MESSAGE_SUCCESS, policyToDelete, model.getSortedFilteredPersonList().get(1).getName()),
                 expectedModel);
 
         assertThrows(CommandException.class, () -> deletePolicyCommand.execute(model),
@@ -96,7 +96,7 @@ public class DeletePolicyCommandTest {
         expectedModel.deletePolicy(model.getAddressBook().getPersonList().get(1), policyToDelete);
 
         CommandTestUtil.assertCommandSuccess(deletePolicyCommand, model,
-                String.format(MESSAGE_SUCCESS, policyToDelete , model.getFilteredPersonList().get(0).getName()),
+                String.format(MESSAGE_SUCCESS, policyToDelete , model.getSortedFilteredPersonList().get(0).getName()),
                 expectedModel);
     }
 

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -44,15 +44,15 @@ public class EditCommandTest {
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPerson);
+        expectedModel.setPerson(model.getSortedFilteredPersonList().get(0), editedPerson);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
     public void execute_someFieldsSpecifiedUnfilteredList_success() {
-        Index indexLastPerson = Index.fromOneBased(model.getFilteredPersonList().size());
-        Person lastPerson = model.getFilteredPersonList().get(indexLastPerson.getZeroBased());
+        Index indexLastPerson = Index.fromOneBased(model.getSortedFilteredPersonList().size());
+        Person lastPerson = model.getSortedFilteredPersonList().get(indexLastPerson.getZeroBased());
 
         PersonBuilder personInList = new PersonBuilder(lastPerson);
         Person editedPerson = personInList.withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
@@ -73,7 +73,7 @@ public class EditCommandTest {
     @Test
     public void execute_noFieldSpecifiedUnfilteredList_success() {
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, new EditPersonDescriptor());
-        Person editedPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person editedPerson = model.getSortedFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
 
@@ -86,7 +86,7 @@ public class EditCommandTest {
     public void execute_filteredList_success() {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
 
-        Person personInFilteredList = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person personInFilteredList = model.getSortedFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         Person editedPerson = new PersonBuilder(personInFilteredList).withName(VALID_NAME_BOB).build();
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON,
                 new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build());
@@ -94,14 +94,14 @@ public class EditCommandTest {
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPerson);
+        expectedModel.setPerson(model.getSortedFilteredPersonList().get(0), editedPerson);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
     public void execute_duplicatePersonUnfilteredList_failure() {
-        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person firstPerson = model.getSortedFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(firstPerson).build();
         EditCommand editCommand = new EditCommand(INDEX_SECOND_PERSON, descriptor);
 
@@ -122,7 +122,7 @@ public class EditCommandTest {
 
     @Test
     public void execute_invalidPersonIndexUnfilteredList_failure() {
-        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        Index outOfBoundIndex = Index.fromOneBased(model.getSortedFilteredPersonList().size() + 1);
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build();
         EditCommand editCommand = new EditCommand(outOfBoundIndex, descriptor);
 

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -61,7 +61,7 @@ public class FindCommandTest {
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Collections.emptyList(), model.getFilteredPersonList());
+        assertEquals(Collections.emptyList(), model.getSortedFilteredPersonList());
     }
 
     @Test
@@ -71,7 +71,7 @@ public class FindCommandTest {
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getFilteredPersonList());
+        assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getSortedFilteredPersonList());
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/LastMetCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/LastMetCommandTest.java
@@ -45,12 +45,12 @@ public class LastMetCommandTest {
         LastMetCommand lastMetCommand = new LastMetCommand(validIndex, new LastMet(validDate));
 
         CommandTestUtil.assertCommandSuccess(lastMetCommand, model,
-                String.format(MESSAGE_SUCCESS, model.getFilteredPersonList().get(0).getName()), expectedModel);
+                String.format(MESSAGE_SUCCESS, model.getSortedFilteredPersonList().get(0).getName()), expectedModel);
     }
 
     @Test
     public void execute_invalidIndex_throwsCommandException() {
-        Index invalidIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        Index invalidIndex = Index.fromOneBased(model.getSortedFilteredPersonList().size() + 1);
         LocalDate validDate = LocalDate.now().minusDays(1);
 
         LastMetCommand lastMetCommand = new LastMetCommand(invalidIndex, new LastMet(validDate));

--- a/src/test/java/seedu/address/logic/commands/MarkCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/MarkCommandTest.java
@@ -36,7 +36,7 @@ public class MarkCommandTest {
 
     @Test
     public void execute_invalidIndex_throwsCommandException() {
-        Index invalidIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        Index invalidIndex = Index.fromOneBased(model.getSortedFilteredPersonList().size() + 1);
 
         MarkCommand markCommand = new MarkCommand(invalidIndex);
 
@@ -47,7 +47,7 @@ public class MarkCommandTest {
     @Test
     public void execute_alreadyDoneSchedule_throwsCommandException() {
         Index validIndex = Index.fromOneBased(1);
-        Person personWithDoneSchedule = model.getFilteredPersonList().get(0);
+        Person personWithDoneSchedule = model.getSortedFilteredPersonList().get(0);
         personWithDoneSchedule.getSchedule().markIsDone();
 
         MarkCommand markCommand = new MarkCommand(validIndex);

--- a/src/test/java/seedu/address/logic/commands/RemarkCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RemarkCommandTest.java
@@ -29,7 +29,7 @@ public class RemarkCommandTest {
 
     @Test
     public void execute_addRemarkUnfilteredList_success() {
-        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person firstPerson = model.getSortedFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         Person editedPerson = new PersonBuilder(firstPerson).withRemark(REMARK_STUB).build();
 
         RemarkCommand remarkCommand = new RemarkCommand(INDEX_FIRST_PERSON, new Remark(editedPerson.getRemark().value));
@@ -44,7 +44,7 @@ public class RemarkCommandTest {
 
     @Test
     public void execute_deleteRemarkUnfilteredList_success() {
-        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person firstPerson = model.getSortedFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         Person editedPerson = new PersonBuilder(firstPerson).withRemark("").build();
 
         RemarkCommand remarkCommand = new RemarkCommand(INDEX_FIRST_PERSON,
@@ -63,9 +63,9 @@ public class RemarkCommandTest {
     public void execute_filteredList_success() {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
 
-        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        Person editedPerson = new PersonBuilder(model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased()))
-                .withRemark(REMARK_STUB).build();
+        Person firstPerson = model.getSortedFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person editedPerson = new PersonBuilder(model.getSortedFilteredPersonList()
+                .get(INDEX_FIRST_PERSON.getZeroBased())).withRemark(REMARK_STUB).build();
 
         RemarkCommand remarkCommand = new RemarkCommand(INDEX_FIRST_PERSON, new Remark(editedPerson.getRemark().value));
 
@@ -79,7 +79,7 @@ public class RemarkCommandTest {
 
     @Test
     public void execute_invalidPersonIndexUnfilteredList_failure() {
-        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        Index outOfBoundIndex = Index.fromOneBased(model.getSortedFilteredPersonList().size() + 1);
         RemarkCommand remarkCommand = new RemarkCommand(outOfBoundIndex, new Remark(VALID_REMARK_BOB));
 
         assertCommandFailure(remarkCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);

--- a/src/test/java/seedu/address/logic/commands/ScheduleCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ScheduleCommandTest.java
@@ -46,12 +46,12 @@ public class ScheduleCommandTest {
         ScheduleCommand scheduleCommand = new ScheduleCommand(validIndex, new Schedule(validDateTime));
 
         CommandTestUtil.assertCommandSuccess(scheduleCommand, model,
-                String.format(MESSAGE_SUCCESS, model.getFilteredPersonList().get(0).getName()), expectedModel);
+                String.format(MESSAGE_SUCCESS, model.getSortedFilteredPersonList().get(0).getName()), expectedModel);
     }
 
     @Test
     public void execute_invalidIndex_throwsCommandException() {
-        Index invalidIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        Index invalidIndex = Index.fromOneBased(model.getSortedFilteredPersonList().size() + 1);
         LocalDateTime validDateTime = LocalDateTime.now().plusDays(1);
 
         ScheduleCommand scheduleCommand = new ScheduleCommand(invalidIndex, new Schedule(validDateTime));

--- a/src/test/java/seedu/address/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortCommandTest.java
@@ -33,7 +33,8 @@ public class SortCommandTest {
     @Test
     public void execute_sortNoPersonsModel_sortSuccesstul() {
         ModelManager expectedEmptyModel = new ModelManager(new AddressBook(new AddressBook()), new UserPrefs());
-        expectedEmptyModel.sortFilteredPersonList(PersonComparator.getComparator(SortCriteria.PRIORITY, SortOrder.ASC));
+        expectedEmptyModel.updateSortPersonComparator(
+                PersonComparator.getComparator(SortCriteria.PRIORITY, SortOrder.ASC));
         CommandTestUtil.assertCommandSuccess(new SortCommand(SortCriteria.PRIORITY, SortOrder.ASC),
                 new ModelManager(new AddressBook(new AddressBook()), new UserPrefs()),
                 invalidSortPriorityAsc, expectedEmptyModel);
@@ -42,7 +43,7 @@ public class SortCommandTest {
     @Test
     public void execute_sortPersonsModel_sortSuccessful() {
         ModelManager expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        expectedModel.sortFilteredPersonList(PersonComparator.getComparator(SortCriteria.PRIORITY, SortOrder.ASC));
+        expectedModel.updateSortPersonComparator(PersonComparator.getComparator(SortCriteria.PRIORITY, SortOrder.ASC));
         CommandTestUtil.assertCommandSuccess(new SortCommand(SortCriteria.PRIORITY, SortOrder.ASC), model,
                 invalidSortPriorityAsc, expectedModel);
     }
@@ -51,7 +52,7 @@ public class SortCommandTest {
     public void execute_invalidSortCriteria_sortSuccessful() {
         ModelManager expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         SortCommand sortCommand = new SortCommand(SortCriteria.INVALID, SortOrder.ASC);
-        expectedModel.sortFilteredPersonList(PersonComparator.getComparator(SortCriteria.INVALID, SortOrder.ASC));
+        expectedModel.updateSortPersonComparator(PersonComparator.getComparator(SortCriteria.INVALID, SortOrder.ASC));
         String expectedMessage = SortCommand.getMessageSuccess(SortCriteria.INVALID, SortOrder.ASC);
         CommandTestUtil.assertCommandSuccess(sortCommand, model, expectedMessage, expectedModel);
     }
@@ -60,7 +61,8 @@ public class SortCommandTest {
     public void execute_invalidSortOrder_sortSuccessful() {
         ModelManager expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         SortCommand sortCommand = new SortCommand(SortCriteria.PRIORITY, SortOrder.INVALID);
-        expectedModel.sortFilteredPersonList(PersonComparator.getComparator(SortCriteria.PRIORITY, SortOrder.INVALID));
+        expectedModel.updateSortPersonComparator(
+                PersonComparator.getComparator(SortCriteria.PRIORITY, SortOrder.INVALID));
         String expectedMessage = SortCommand.getMessageSuccess(SortCriteria.PRIORITY, SortOrder.INVALID);
         CommandTestUtil.assertCommandSuccess(sortCommand, model, expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/address/logic/commands/ViewCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ViewCommandTest.java
@@ -29,7 +29,7 @@ public class ViewCommandTest {
 
     @Test
     public void execute_validIndexUnfilteredList_success() {
-        Person personToView = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person personToView = model.getSortedFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         ViewCommand viewCommand = new ViewCommand(INDEX_FIRST_PERSON);
 
         String expectedMessage = String.format(ViewCommand.MESSAGE_VIEW_PERSON_SUCCESS,
@@ -43,7 +43,7 @@ public class ViewCommandTest {
 
     @Test
     public void execute_invalidIndexUnfilteredList_throwsCommandException() {
-        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        Index outOfBoundIndex = Index.fromOneBased(model.getSortedFilteredPersonList().size() + 1);
         ViewCommand viewCommand = new ViewCommand(outOfBoundIndex);
 
         assertCommandFailure(viewCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
@@ -53,7 +53,7 @@ public class ViewCommandTest {
     public void execute_validIndexFilteredList_success() {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
 
-        Person personToView = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person personToView = model.getSortedFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         ViewCommand viewCommand = new ViewCommand(INDEX_FIRST_PERSON);
 
         String expectedMessage = String.format(ViewCommand.MESSAGE_VIEW_PERSON_SUCCESS,

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -3,6 +3,7 @@ package seedu.address.model;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.model.Model.COMPARATOR_SHOW_ORIGINAL_ORDER;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE;
@@ -98,7 +99,7 @@ public class ModelManagerTest {
 
     @Test
     public void getFilteredPersonList_modifyList_throwsUnsupportedOperationException() {
-        assertThrows(UnsupportedOperationException.class, () -> modelManager.getFilteredPersonList().remove(0));
+        assertThrows(UnsupportedOperationException.class, () -> modelManager.getSortedFilteredPersonList().remove(0));
     }
 
     @Test
@@ -131,6 +132,7 @@ public class ModelManagerTest {
 
         // resets modelManager to initial state for upcoming tests
         modelManager.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        modelManager.updateSortPersonComparator(COMPARATOR_SHOW_ORIGINAL_ORDER);
 
         // different userPrefs -> returns false
         UserPrefs differentUserPrefs = new UserPrefs();

--- a/src/test/java/seedu/address/model/person/PersonComparatorTest.java
+++ b/src/test/java/seedu/address/model/person/PersonComparatorTest.java
@@ -95,10 +95,10 @@ public class PersonComparatorTest {
         // sort by invalid or default criteria
         Comparator<Person> invalidAscComparator = PersonComparator.getComparator(SortCriteria.INVALID, SortOrder.ASC);
         // ascending
-        assertTrue(invalidAscComparator.compare(alice, bob) < 0);
+        assertTrue(invalidAscComparator.compare(alice, bob) == 0);
         assertEquals(0, invalidAscComparator.compare(alice, aliceCopy));
         // descending
-        assertTrue(invalidAscComparator.compare(alice, bob) < 0);
+        assertTrue(invalidAscComparator.compare(alice, bob) == 0);
         assertEquals(0, invalidAscComparator.compare(alice, aliceCopy));
     }
 }

--- a/src/test/java/seedu/address/testutil/TestUtil.java
+++ b/src/test/java/seedu/address/testutil/TestUtil.java
@@ -36,20 +36,20 @@ public class TestUtil {
      * Returns the middle index of the person in the {@code model}'s person list.
      */
     public static Index getMidIndex(Model model) {
-        return Index.fromOneBased(model.getFilteredPersonList().size() / 2);
+        return Index.fromOneBased(model.getSortedFilteredPersonList().size() / 2);
     }
 
     /**
      * Returns the last index of the person in the {@code model}'s person list.
      */
     public static Index getLastIndex(Model model) {
-        return Index.fromOneBased(model.getFilteredPersonList().size());
+        return Index.fromOneBased(model.getSortedFilteredPersonList().size());
     }
 
     /**
      * Returns the person in the {@code model}'s person list at {@code index}.
      */
     public static Person getPerson(Model model, Index index) {
-        return model.getFilteredPersonList().get(index.getZeroBased());
+        return model.getSortedFilteredPersonList().get(index.getZeroBased());
     }
 }


### PR DESCRIPTION
Bug detected with sorting when other commands happen, such as sorting then adding policy. Bug detected with not updating client view after sorting.

Refactoring sorting will allow filteredPersons to revert to being immutable and final, while allowing combinations of both sorting and filtering effects.

Let's
* Refactor sort, by storing the comparator in model and allowing this to be set.
* Layer of sorting logic when filtered list is obtained, so that filtered list can remain immutable.
* Abstract setting the display of client to the first person in the sorted and filtered list, since its used in find, sort and list

1. When sort then list, the order of clients reverts back to original order
2. When sort, the client displayed is the first in the sorted list
3. filteredPerson in ModelManager is once again final and immutable
4. When sort then addpolicy, the order of clients reverts to original order

<img width="1274" alt="Screenshot 2024-04-02 at 4 14 28 PM" src="https://github.com/AY2324S2-CS2103T-W12-1/tp/assets/66112309/f00a2149-0310-4fb6-9f67-9f003c4c9aea">

<img width="1277" alt="Screenshot 2024-04-02 at 4 14 44 PM" src="https://github.com/AY2324S2-CS2103T-W12-1/tp/assets/66112309/626952c7-1327-4606-9b23-4330dabd9e31">

<img width="1279" alt="Screenshot 2024-04-02 at 4 15 08 PM" src="https://github.com/AY2324S2-CS2103T-W12-1/tp/assets/66112309/36682a5e-d349-408a-9c73-3769df2f5cf6">

<img width="487" alt="Screenshot 2024-04-02 at 4 25 07 PM" src="https://github.com/AY2324S2-CS2103T-W12-1/tp/assets/66112309/67b8ecc7-bc29-4a42-a0fc-077aa39969c5">
