### PR TITLE
Fix birthday sorting regardless of year bug

### DIFF
--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -149,6 +149,6 @@ public class AddressBook implements ReadOnlyAddressBook {
      * @return list of persons who have upcoming birthdays
      */
     public ObservableList<Person> getPersonsWithUpcomingBirthdays() {
-        return persons.filterHaveUpcomingBirthday();
+        return persons.sortFilterHaveUpcomingBirthday();
     }
 }

--- a/src/main/java/seedu/address/model/person/Birthday.java
+++ b/src/main/java/seedu/address/model/person/Birthday.java
@@ -80,4 +80,16 @@ public class Birthday implements Comparable<Birthday> {
     public int compareTo(Birthday other) {
         return date.compareTo(other.date);
     }
+
+    /**
+     * Compares the month and date of this birthday with another birthday.
+     * Ignores the year.
+     *
+     * @param other The other birthday to compare with
+     * @return A negative integer, zero, or a positive integer as this birthday is before, at the same time, or after
+     */
+    public int compareByBirthdayMonthAndDateOnly(Birthday other) {
+        int currentYear = LocalDate.now().getYear();
+        return date.withYear(currentYear).compareTo(other.date.withYear(currentYear));
+    }
 }

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -9,6 +9,8 @@ import java.util.List;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import javafx.collections.transformation.FilteredList;
+import javafx.collections.transformation.SortedList;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.model.person.exceptions.PersonNotFoundException;
 
@@ -184,14 +186,13 @@ public class UniquePersonList implements Iterable<Person> {
      * Returns the list of persons who have upcoming birthdays, sorted by birthday.
      * @return list of persons who have upcoming birthdays
      */
-    public ObservableList<Person> filterHaveUpcomingBirthday() {
-        ObservableList<Person> personsWithUpcomingBirthdays = FXCollections.observableArrayList();
-        for (Person person : internalList) {
-            if (person.hasUpcomingBirthday()) {
-                personsWithUpcomingBirthdays.add(person);
-            }
-        }
-        personsWithUpcomingBirthdays.sort(Comparator.comparing(Person::getBirthday));
-        return personsWithUpcomingBirthdays;
+    public ObservableList<Person> sortFilterHaveUpcomingBirthday() {
+        FilteredList<Person> filteredPersonsWithUpcomingBirthdays = new FilteredList<>(internalList);
+        filteredPersonsWithUpcomingBirthdays.setPredicate(Person::hasUpcomingBirthday);
+        SortedList<Person> sortedFilteredPersonsWithUpcomingBirthdays =
+                new SortedList<>(filteredPersonsWithUpcomingBirthdays);
+        sortedFilteredPersonsWithUpcomingBirthdays.setComparator(
+                Comparator.comparing(Person::getBirthday, Birthday::compareByBirthdayMonthAndDateOnly));
+        return sortedFilteredPersonsWithUpcomingBirthdays;
     }
 }

--- a/src/test/java/seedu/address/model/person/BirthdayTest.java
+++ b/src/test/java/seedu/address/model/person/BirthdayTest.java
@@ -1,5 +1,6 @@
 package seedu.address.model.person;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
@@ -120,5 +121,25 @@ public class BirthdayTest {
 
         // different values -> returns false
         assertFalse(birthday.equals(new Birthday("1993-09-23")));
+    }
+
+    @Test
+    public void compareByBirthdayMonthAndDateOnly() {
+        Birthday birthday = new Birthday("1993-09-22");
+
+        // same values -> returns 0 regardless of year
+        assertEquals(0, birthday.compareByBirthdayMonthAndDateOnly(new Birthday("1998-09-22")));
+
+        // different month -> returns negative integer regardless of year
+        assertTrue(birthday.compareByBirthdayMonthAndDateOnly(new Birthday("1992-10-22")) < 0);
+
+        // different day -> returns negative integer regardless of year
+        assertTrue(birthday.compareByBirthdayMonthAndDateOnly(new Birthday("1991-09-23")) < 0);
+
+        // different month -> returns positive integer regardless of year
+        assertTrue(birthday.compareByBirthdayMonthAndDateOnly(new Birthday("2023-08-22")) > 0);
+
+        // different day -> returns positive integer regardless of year
+        assertTrue(birthday.compareByBirthdayMonthAndDateOnly(new Birthday("2008-09-01")) > 0);
     }
 }

--- a/src/test/java/seedu/address/model/person/UniquePersonListTest.java
+++ b/src/test/java/seedu/address/model/person/UniquePersonListTest.java
@@ -7,6 +7,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BENSON;
 import static seedu.address.testutil.TypicalPersons.BOB;
 
 import java.time.LocalDate;
@@ -178,6 +179,29 @@ public class UniquePersonListTest {
 
     @Test
     public void filterHaveUpcomingBirthday() {
+        Person personWithUpcomingBirthdaySecond = new PersonBuilder(ALICE).withBirthday(
+                DateUtil.parseDateToString(LocalDate.now().plusWeeks(1)
+                        .minusYears(40))).build();
+        Person personWithNoUpcomingBirthday = new PersonBuilder(BOB).withBirthday(
+                DateUtil.parseDateToString(LocalDate.now().minusDays(1)
+                        .minusYears(30))).build();
+        Person personWithUpcomingBirthdayFirst = new PersonBuilder(BENSON).withBirthday(
+                DateUtil.parseDateToString(LocalDate.now().plusDays(3)
+                        .minusYears(30))).build();
+
+        UniquePersonList newPersonsList = new UniquePersonList();
+        newPersonsList.add(personWithUpcomingBirthdaySecond);
+        newPersonsList.add(personWithNoUpcomingBirthday);
+        newPersonsList.add(personWithUpcomingBirthdayFirst);
+        ObservableList<Person> birthdayList = newPersonsList.sortFilterHaveUpcomingBirthday();
+
+        assertEquals(2, birthdayList.size());
+        assertEquals(personWithUpcomingBirthdayFirst, birthdayList.get(0));
+        assertEquals(personWithUpcomingBirthdaySecond, birthdayList.get(1));
+    }
+
+    @Test
+    public void sortFilterHaveUpcomingBirthday() {
         Person personWithUpcomingBirthday = new PersonBuilder(ALICE).withBirthday(
                 DateUtil.parseDateToString(LocalDate.now().plusWeeks(1)
                         .minusYears(40))).build();
@@ -188,7 +212,7 @@ public class UniquePersonListTest {
         UniquePersonList newPersonsList = new UniquePersonList();
         newPersonsList.add(personWithUpcomingBirthday);
         newPersonsList.add(personWithNoUpcomingBirthday);
-        ObservableList<Person> birthdayList = newPersonsList.filterHaveUpcomingBirthday();
+        ObservableList<Person> birthdayList = newPersonsList.sortFilterHaveUpcomingBirthday();
 
         assertEquals(1, birthdayList.size());
         assertTrue(birthdayList.contains(personWithUpcomingBirthday));


### PR DESCRIPTION
Let's
* Birthday reminders now sort by month and day only and regardless of year.
* Separate comparator method for sorting by month and day only for birthday reminders, since we still need to reserve the comparator that sorts by year, month and date for the sort client list by birthday function.
* Use withYear() when disregarding date, so that 29 Feb is truncated to 28 Feb on non-leap years.

test1 is before test3, since the month and day is smaller, although the year is larger.

<img width="1275" alt="Screenshot 2024-04-03 at 5 20 23 PM" src="https://github.com/AY2324S2-CS2103T-W12-1/tp/assets/66112309/89594c0d-d760-48dd-8eb4-78e209967cdb">
