### PR TITLE
Fix grammar and space error in addpolicy and deletepolicy

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeletePolicyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeletePolicyCommand.java
@@ -23,7 +23,7 @@ public class DeletePolicyCommand extends Command {
     public static final String COMMAND_WORD = "deletepolicy";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Deletes a policy from the policy list of the client"
-            + "identified by the index number used in the displayed client list.\n"
+            + " identified by the index number used in the displayed client list.\n"
             + "Parameters: "
             + "INDEX (must be a positive integer) "
             + PREFIX_POLICYID + "POLICYID\n"

--- a/src/main/java/seedu/address/model/policy/Policy.java
+++ b/src/main/java/seedu/address/model/policy/Policy.java
@@ -16,7 +16,7 @@ public class Policy {
      * The constant MESSAGE_CONSTRAINTS_ID.
      */
     public static final String MESSAGE_CONSTRAINTS_ID =
-            "Policy ID should only contain numbers, and it should be at least 1 digits long";
+            "Policy ID should only contain numbers, and it should be at least 1 digit long";
     /**
      * The constant VALIDATION_NAME_REGEX.
      */


### PR DESCRIPTION
Fixed missing spaces and additional "s" in addpolicy and deletepolicy. Relates #170, #171