### PR TITLE
Fix PE-D Bugs for UG and Email

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -386,6 +386,11 @@ Examples:
 * `add n/John Doe c/98765432 e/johnd@example.com a/311, Clementi Ave 2, #02-25 d/1990-01-01 p/low t/friends t/owesMoney`
 * `add n/Betsy Crowe t/friend p/vip e/betsycrowe@example.com a/Hougang Road 12 c/1234567 t/buddy d/1979-03-04`
 
+<box type="tip">
+
+**Tip:** If you are missing information for some fields, you can enter placeholder values like `e/placeholder@email.com`!
+</box>
+
 **Before Command:**
 
 Suppose you just met a new client! Let's add James Wee to your client list and his following details:
@@ -580,25 +585,21 @@ Format: `remark INDEX [r/REMARK]`
 * Adds a note to the client at the specified `INDEX`.
 * The index refers to the index number shown in the displayed client list.
 * The index **must be a positive integer** 1, 2, 3, …​
+* If `r/REMARK` is not present, or if nothing is typed after `r/`, the current remark for the client will be removed. 
 
 Examples:
 * `remark 2 r/Has 2 school-age children and 1 elderly dependent` adds a remark for the 2nd client in the client list.
-* `remark 1` deletes the remark for the 1st client in the client list.
+* `remark 1` or `remark 1 r/` deletes the remark for the 1st client in the client list.
 
 
 <box type="tip">
 
-**Tip:** To remove a remark, you can use either `remark INDEX` or `remark INDEX r/`!
+**Tip:** If you make a typo in your remark, you don't have to delete everything again! Just add a second prefix, for example: `remark 1 r/Speeks Enngliish r/Speaks English` will only save `Speaks English`.
 </box>
 
 <box type="info">
 
-**Note:** ClientCare allows you to put up to 550 characters long for remark before characters are truncated in fullscreen.
-</box>
-
-<box type="warning" theme="danger" icon=":warning:">
-
-**CAUTION**: Avoid using the `r/` prefix again in your remark, as it won't capture anything before it. `remark 1 r/Speaks English r/Prefers email` will only save `Prefers email`!
+**Note:** ClientCare allows you to put up to 550 characters for `REMARK` before characters are truncated in fullscreen.
 </box>
 
 **Before Command:**
@@ -1211,6 +1212,9 @@ The default period is 90 days. You can change this value using the `set` command
 
 This refers to features or commands in ClientCare that are not related to Client, Schedules or Policies.
 
+15. **Truncated**
+
+If a text is truncated in the display, this means that the full text has been shortened, with an ellipsis `...` at the end.
 
 <div style="page-break-after: always;"></div>
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -1036,7 +1036,7 @@ Furthermore, certain edits can cause the ClientCare to behave in unexpected ways
 
 
 **Q** : Why is ClientCare saying my date format is wrong?<br/>
-**A** : Ensure that your date format is in YYYY-MM-DD instead of MM-DD-YYYY.
+**A** : Ensure that your date format is in YYYY-MM-DD instead of DD-MM-YYYY.
 
 
 **Q** : Why is my client not showing up in Last Met Display?<br/>

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -1197,7 +1197,7 @@ For example: mike@gmail.com
 
 This means that the new value added will not be added on top of the existing information. This is especially so for Tags.
 For example, if a Client currently has 2 tags `friend` and `important`, editing the tags with `high` will override the previous 2 tags.
-The Client will only have the high `high` tag upon a success edit. To preserve all the tags, users must key in all previous tags in addition
+The Client will only have the `high` tag upon a success edit. To preserve all the tags, users must key in all previous tags in addition
 to their new tag they wish to add.
 
 <div style="page-break-after: always;"></div>

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -369,6 +369,7 @@ All other fields (with the exception of tags) cannot have duplicate fields. For 
 **Note:** The name of the client is case-sensitive. `John` and `john` will be regarded as different people.
 </box>
 
+
 Fields usage for client details:
 
 | Field            | Usage                                                                                    | Example                         |
@@ -593,6 +594,11 @@ Examples:
 <box type="info">
 
 **Note:** ClientCare allows you to put up to 550 characters long for remark before characters are truncated in fullscreen.
+</box>
+
+<box type="warning" theme="danger" icon=":warning:">
+
+**CAUTION**: Avoid using the `r/` prefix again in your remark, as it won't capture anything before it. `remark 1 r/Speaks English r/Prefers email` will only save `Prefers email`!
 </box>
 
 **Before Command:**

--- a/src/main/java/seedu/address/logic/parser/RemarkCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/RemarkCommandParser.java
@@ -2,23 +2,13 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_BIRTHDAY;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PRIORITY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_REMARK;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.logic.commands.RemarkCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Remark;
-import seedu.address.model.tag.Tag;
-
-import java.util.Set;
 
 /**
  * Parses input arguments and creates a new {@code RemarkCommand} object

--- a/src/main/java/seedu/address/logic/parser/RemarkCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/RemarkCommandParser.java
@@ -2,6 +2,12 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_BIRTHDAY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PRIORITY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_REMARK;
 
 import seedu.address.commons.core.index.Index;
@@ -30,6 +36,7 @@ public class RemarkCommandParser implements Parser<RemarkCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, RemarkCommand.MESSAGE_USAGE), ive);
         }
 
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_REMARK);
         String remark = argMultimap.getValue(PREFIX_REMARK).orElse("");
 
         return new RemarkCommand(index, new Remark(remark));

--- a/src/main/java/seedu/address/logic/parser/RemarkCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/RemarkCommandParser.java
@@ -40,9 +40,7 @@ public class RemarkCommandParser implements Parser<RemarkCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, RemarkCommand.MESSAGE_USAGE), ive);
         }
 
-        // argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_REMARK);
-        String remark = String.join(" r/", argMultimap.getAllValues(PREFIX_REMARK));
-        // String remark = argMultimap.getValue(PREFIX_REMARK).orElse("");
+        String remark = argMultimap.getValue(PREFIX_REMARK).orElse("");
 
         return new RemarkCommand(index, new Remark(remark));
     }

--- a/src/main/java/seedu/address/logic/parser/RemarkCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/RemarkCommandParser.java
@@ -9,12 +9,16 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PRIORITY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_REMARK;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.logic.commands.RemarkCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Remark;
+import seedu.address.model.tag.Tag;
+
+import java.util.Set;
 
 /**
  * Parses input arguments and creates a new {@code RemarkCommand} object
@@ -36,8 +40,9 @@ public class RemarkCommandParser implements Parser<RemarkCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, RemarkCommand.MESSAGE_USAGE), ive);
         }
 
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_REMARK);
-        String remark = argMultimap.getValue(PREFIX_REMARK).orElse("");
+        // argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_REMARK);
+        String remark = String.join(" r/", argMultimap.getAllValues(PREFIX_REMARK));
+        // String remark = argMultimap.getValue(PREFIX_REMARK).orElse("");
 
         return new RemarkCommand(index, new Remark(remark));
     }

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -23,7 +23,7 @@ public class Email implements Comparable<Email> {
             + "    - have each domain label consist of alphanumeric characters, separated only by hyphens, if any.";
     // alphanumeric and special characters
     private static final String ALPHANUMERIC_NO_UNDERSCORE = "[^\\W_]+"; // alphanumeric characters except underscore
-    private static final String LOCAL_PART_REGEX = "^" + ALPHANUMERIC_NO_UNDERSCORE + "([" + SPECIAL_CHARACTERS + "]"
+    private static final String LOCAL_PART_REGEX = "^" + ALPHANUMERIC_NO_UNDERSCORE + "([" + SPECIAL_CHARACTERS + "]+"
             + ALPHANUMERIC_NO_UNDERSCORE + ")*";
     private static final String DOMAIN_PART_REGEX = ALPHANUMERIC_NO_UNDERSCORE
             + "(-" + ALPHANUMERIC_NO_UNDERSCORE + ")*";

--- a/src/test/java/seedu/address/model/person/EmailTest.java
+++ b/src/test/java/seedu/address/model/person/EmailTest.java
@@ -44,7 +44,6 @@ public class EmailTest {
         assertFalse(Email.isValidEmail("peter@jack@example.com")); // '@' symbol in local part
         assertFalse(Email.isValidEmail("-peterjack@example.com")); // local part starts with a hyphen
         assertFalse(Email.isValidEmail("peterjack-@example.com")); // local part ends with a hyphen
-        assertFalse(Email.isValidEmail("peter..jack@example.com")); // local part has two consecutive periods
         assertFalse(Email.isValidEmail("peterjack@example@com")); // '@' symbol in domain name
         assertFalse(Email.isValidEmail("peterjack@.example.com")); // domain name starts with a period
         assertFalse(Email.isValidEmail("peterjack@example.com.")); // domain name ends with a period
@@ -57,6 +56,7 @@ public class EmailTest {
         assertTrue(Email.isValidEmail("PeterJack.1190@example.com")); // period in local part
         assertTrue(Email.isValidEmail("PeterJack+1190@example.com")); // '+' symbol in local part
         assertTrue(Email.isValidEmail("PeterJack-1190@example.com")); // hyphen in local part
+        assertTrue(Email.isValidEmail("peter..jack@example.com")); // local part has two consecutive periods
         assertTrue(Email.isValidEmail("a@bc")); // minimal
         assertTrue(Email.isValidEmail("test@localhost")); // alphabets only
         assertTrue(Email.isValidEmail("123@145")); // numeric local part and domain name


### PR DESCRIPTION
* Changed Regex in isValidEmail to allow for consecutive special characters in local part domain #160 
* Added tip to UG to use placeholder values to bypass restrictions for add command, closes #169 
* Added tip to UG to use additional prefixes to fix typos, closes #136 #141 
* Added truncated to glossary
* Fixed typo in date format in Q&A
* Fixed typo in glossary
